### PR TITLE
fix: add user-friendly validation when an invalid input object is provided

### DIFF
--- a/src/artifact-utils.ts
+++ b/src/artifact-utils.ts
@@ -1,4 +1,5 @@
 import { ElectronArtifactDetails, MirrorOptions } from './types';
+import { ensureIsTruthyString } from './utils';
 
 const BASE_URL = 'https://github.com/electron/electron/releases/download/';
 const NIGHTLY_BASE_URL = 'https://github.com/electron/nightlies/releases/download/';
@@ -12,6 +13,9 @@ export function getArtifactFileName(
   details: ElectronArtifactDetails,
   usage: FileNameUse = FileNameUse.LOCAL,
 ) {
+  ensureIsTruthyString(details, 'artifactName');
+  ensureIsTruthyString(details, 'version');
+
   if (details.isGeneric) {
     // When downloading we have to use the artifact name directly as that it was is stored in the release on GitHub
     if (usage === FileNameUse.REMOTE) {
@@ -21,6 +25,8 @@ export function getArtifactFileName(
     return `${details.version}-${details.artifactName}`;
   }
 
+  ensureIsTruthyString(details, 'platform');
+  ensureIsTruthyString(details, 'arch');
   return `${[details.artifactName, details.version, details.platform, details.arch].join('-')}.zip`;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { getArtifactFileName, getArtifactRemoteURL, FileNameUse } from './artifa
 import { ElectronArtifactDetails, ElectronDownloadRequestOptions } from './types';
 import { Cache } from './Cache';
 import { getDownloaderForSystem } from './downloader-resolver';
-import { withTempDirectory, normalizeVersion, getHostArch } from './utils';
+import { withTempDirectory, normalizeVersion, getHostArch, ensureIsTruthyString } from './utils';
 
 export { getHostArch } from './utils';
 
@@ -36,9 +36,10 @@ export function download(
  * @param artifactDetails The information required to download the artifact
  */
 export async function downloadArtifact(_artifactDetails: ElectronArtifactDetails): Promise<string> {
-  const artifactDetails = {
+  const artifactDetails: ElectronArtifactDetails = {
     ..._artifactDetails,
   };
+  ensureIsTruthyString(artifactDetails, 'version');
   artifactDetails.version = normalizeVersion(artifactDetails.version);
 
   const fileName = getArtifactFileName(artifactDetails);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,3 +65,9 @@ export function getNodeArch(arch: string) {
 
   return arch;
 }
+
+export function ensureIsTruthyString<T, K extends keyof T>(obj: T, key: K) {
+  if (!obj[key] || typeof obj[key] !== 'string') {
+    throw new Error(`Expected property "${key}" to be provided as a string but it was not`);
+  }
+}


### PR DESCRIPTION
Those using typescript will get compile errors, we should still have some handy warnings for those not using typescript so they get more descriptive errors than "can not read property startsWith of undefined".