### PR TITLE
chore: raise env-paths requirement to ^2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=8.6"
   },
   "dependencies": {
-    "env-paths": "^2.1.0",
+    "env-paths": "^2.2.0",
     "fs-extra": "^7.0.1",
     "got": "^9.6.0",
     "sumchecker": "^3.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     "declaration": true
   },
   "include": [
-    "src",
-    "typings"
+    "src"
   ]
 }

--- a/typings/ambient.d.ts
+++ b/typings/ambient.d.ts
@@ -1,1 +1,0 @@
-declare module 'env-paths';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,7 +1912,7 @@ env-ci@^3.0.0:
     execa "^1.0.0"
     java-properties "^0.2.9"
 
-env-paths@^2.1.0:
+env-paths@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
   integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==


### PR DESCRIPTION
2.2.0 contains its own TypeScript definition, so there does not need to be any ambient typings.