### PR TITLE
feat: emit warning if downloading a deprecated linux/ia32 binary

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,13 @@ import { getArtifactFileName, getArtifactRemoteURL, FileNameUse } from './artifa
 import { ElectronArtifactDetails, ElectronDownloadRequestOptions } from './types';
 import { Cache } from './Cache';
 import { getDownloaderForSystem } from './downloader-resolver';
-import { withTempDirectory, normalizeVersion, getHostArch, ensureIsTruthyString } from './utils';
+import {
+  withTempDirectory,
+  normalizeVersion,
+  getHostArch,
+  ensureIsTruthyString,
+  isOfficialLinuxIA32Download,
+} from './utils';
 
 export { getHostArch } from './utils';
 
@@ -58,6 +64,19 @@ export async function downloadArtifact(_artifactDetails: ElectronArtifactDetails
       d('Cache hit');
       return cachedPath;
     }
+  }
+
+  if (
+    !artifactDetails.isGeneric &&
+    isOfficialLinuxIA32Download(
+      artifactDetails.platform,
+      artifactDetails.arch,
+      artifactDetails.version,
+      artifactDetails.mirrorOptions,
+    )
+  ) {
+    console.warn('Official Linux/ia32 support is deprecated.');
+    console.warn('For more info: https://electronjs.org/blog/linux-32bit-support');
   }
 
   return await withTempDirectory(async tempFolder => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,3 +71,17 @@ export function ensureIsTruthyString<T, K extends keyof T>(obj: T, key: K) {
     throw new Error(`Expected property "${key}" to be provided as a string but it was not`);
   }
 }
+
+export function isOfficialLinuxIA32Download(
+  platform: string,
+  arch: string,
+  version: string,
+  mirrorOptions?: object,
+) {
+  return (
+    platform === 'linux' &&
+    arch === 'ia32' &&
+    Number(version.slice(1).split('.')[0]) >= 4 &&
+    typeof mirrorOptions === 'undefined'
+  );
+}

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -6,6 +6,7 @@ import {
   withTempDirectory,
   getHostArch,
   ensureIsTruthyString,
+  isOfficialLinuxIA32Download,
 } from '../src/utils';
 
 describe('utils', () => {
@@ -125,6 +126,27 @@ describe('utils', () => {
 
     it('should throw for an invalid string', () => {
       expect(() => ensureIsTruthyString({ a: 1234 }, 'a')).toThrow();
+    });
+  });
+
+  describe('isOfficialLinuxIA32Download()', () => {
+    it('should be true if an official linux/ia32 download with correct version specified', () => {
+      expect(isOfficialLinuxIA32Download('linux', 'ia32', 'v4.0.0')).toEqual(true);
+    });
+
+    it('should be false if mirrorOptions specified', () => {
+      expect(
+        isOfficialLinuxIA32Download('linux', 'ia32', 'v4.0.0', { mirror: 'mymirror' }),
+      ).toEqual(false);
+    });
+
+    it('should be false if too early version specified', () => {
+      expect(isOfficialLinuxIA32Download('linux', 'ia32', 'v3.0.0')).toEqual(false);
+    });
+
+    it('should be false if wrong platform/arch specified', () => {
+      expect(isOfficialLinuxIA32Download('win32', 'ia32', 'v4.0.0')).toEqual(false);
+      expect(isOfficialLinuxIA32Download('linux', 'x64', 'v4.0.0')).toEqual(false);
     });
   });
 });


### PR DESCRIPTION
Linux/ia32 support was deprecated as of 4.0.0, see blog post: https://electronjs.org/blog/linux-32bit-support