### PR TITLE
fix: Export all types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from './utils';
 
 export { getHostArch } from './utils';
+export * from './types';
 
 const d = debug('@electron/get:index');
 const sumchecker: typeof import('sumchecker').default = require('sumchecker');


### PR DESCRIPTION
This PR will
- export all types so interfaces like `ElectronDownloadRequestOptions` can be imported.

cc @MarshallOfSound @malept 