### PR TITLE
fix: ensure the SHASUM download call provides mirrorOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ export async function downloadArtifact(_artifactDetails: ElectronArtifactDetails
         force: artifactDetails.force,
         downloadOptions: artifactDetails.downloadOptions,
         downloader: artifactDetails.downloader,
+        mirrorOptions: artifactDetails.mirrorOptions,
       });
 
       await sumchecker('sha256', shasumPath, path.dirname(tempDownloadPath), [


### PR DESCRIPTION
Fixes https://github.com/electron/get/issues/108