### PR TITLE
feat: add optional "tempDirectory" download request option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { Cache } from './Cache';
 import { getDownloaderForSystem } from './downloader-resolver';
 import { initializeProxy } from './proxy';
 import {
-  withTempDirectory,
+  withTempDirectoryIn,
   normalizeVersion,
   getHostArch,
   ensureIsTruthyString,
@@ -99,7 +99,7 @@ export async function downloadArtifact(
     console.warn('For more info: https://electronjs.org/blog/linux-32bit-support');
   }
 
-  return await withTempDirectory(async tempFolder => {
+  return await withTempDirectoryIn(artifactDetails.tempDirectory, async tempFolder => {
     const tempDownloadPath = path.resolve(tempFolder, getArtifactFileName(artifactDetails));
 
     const downloader = artifactDetails.downloader || (await getDownloaderForSystem());

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,11 @@ export interface ElectronDownloadRequestOptions {
    * built-in [[GotDownloader]].
    */
   downloader?: Downloader<any>;
+  /**
+   * A temporary directory for downloads.
+   * It is used before artifacts are put into cache.
+   */
+  tempDirectory?: string;
 }
 
 export type ElectronPlatformArtifactDetails = {


### PR DESCRIPTION
Sometimes `os.tmpdir()` is not the best place to store temporary files. Let' give user more control over it.