### PR TITLE
fix: use armv7l if process.config.variable.arm_version is undefined

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,9 +64,8 @@ export function getNodeArch(arch: string) {
       case '6':
         return uname();
       case '7':
-        return 'armv7l';
       default:
-        break;
+        return 'armv7l';
     }
   }
 

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -97,7 +97,7 @@ describe('utils', () => {
         value: 'arm',
       });
       process.config.variables = {} as any;
-      expect(getHostArch()).toEqual('arm');
+      expect(getHostArch()).toEqual('armv7l');
     });
 
     it('should return uname on arm 6', () => {


### PR DESCRIPTION
In the case where `process.config.variable.arm_version` is undefined `arm` ends up being used as the arch which is not a valid arch for Electron, so this PR changes that case to return `armv7l` so that a valid arch is returned.

Resolves https://github.com/electron/electron/issues/21070