### PR TITLE
chore(deps): upgrade sumchecker to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fs-extra": "^8.1.0",
     "got": "^9.6.0",
     "sanitize-filename": "^1.6.2",
-    "sumchecker": "^3.0.0"
+    "sumchecker": "^3.0.1"
   },
   "devDependencies": {
     "@continuous-auth/semantic-release-npm": "^1.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import debug from 'debug';
 import * as path from 'path';
+import * as sumchecker from 'sumchecker';
 
 import { getArtifactFileName, getArtifactRemoteURL } from './artifact-utils';
 import {
@@ -23,7 +24,6 @@ export { initializeProxy } from './proxy';
 export * from './types';
 
 const d = debug('@electron/get:index');
-const sumchecker: typeof import('sumchecker').default = require('sumchecker');
 
 if (process.env.ELECTRON_GET_USE_PROXY) {
   initializeProxy();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6673,10 +6673,10 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-sumchecker@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-3.0.0.tgz#da5457b4605184575c76540e5e99cc777cb8ce4c"
-  integrity sha512-yreseuC/z4iaodVoq07XULEOO9p4jnQazO7mbrnDSvWAU/y2cbyIKs+gWJptfcGu9R+1l27K8Rkj0bfvqnBpgQ==
+sumchecker@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-3.0.1.tgz#6377e996795abb0b6d348e9b3e1dfb24345a8e42"
+  integrity sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==
   dependencies:
     debug "^4.1.0"
 


### PR DESCRIPTION
This fixes the TypeScript definitions so we don't have to use `require()` for `sumchecker`.