### PR TITLE
feat: add an option to remove / use the 'v' prefix when normalizing the version

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ const nightlyZipFilePath = await download('8.0.0-nightly.20190901', {
 // Will download from https://nightly.example.com/nightlies/nightly-linux.zip
 ```
 
+**Note:** If your mirror uses directories in the format `1.2.3` instead of `v.1.2.3` you
+should set `ELECTRON_GET_NO_V_PREFIX=1` or `npm config set electron_get_no_v_prefix 1`. Notably
+the `npm.taobao.org` mirror requires that you use this option.
+
 ## How It Works
 
 This module downloads Electron to a known place on your system and caches it

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,9 +30,12 @@ export async function withTempDirectory<T>(fn: (directory: string) => Promise<T>
 }
 
 export function normalizeVersion(version: string) {
-  if (!version.startsWith('v')) {
-    return `v${version}`;
+  if (process.env.ELECTRON_GET_NO_V_PREFIX || process.env.npm_config_electron_get_no_v_prefix) {
+    if (version.startsWith('v')) return version.substr(1);
+    return version;
   }
+
+  if (!version.startsWith('v')) return `v${version}`;
   return version;
 }
 

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -18,6 +18,24 @@ describe('utils', () => {
     it('should auto prefix a version with a v if it does not already start with a v', () => {
       expect(normalizeVersion('3.2.1')).toEqual('v3.2.1');
     });
+
+    describe('with ELECTRON_GET_NO_V_PREFIX set', () => {
+      beforeEach(() => {
+        process.env.ELECTRON_GET_NO_V_PREFIX = '1';
+      });
+
+      afterEach(() => {
+        delete process.env.ELECTRON_GET_NO_V_PREFIX;
+      });
+
+      it('should do nothing if the version does not start with a v', () => {
+        expect(normalizeVersion('3.2.1')).toEqual('3.2.1');
+      });
+
+      it('should remove the v prefix if the version starts with a v', () => {
+        expect(normalizeVersion('v1.2.3')).toEqual('1.2.3');
+      });
+    });
   });
 
   describe('uname()', () => {


### PR DESCRIPTION
Closes #123
Closes #120 