### PR TITLE
feat: fallback to default platform/arch if undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,9 +62,9 @@ export async function downloadArtifact(
         ..._artifactDetails,
       }
     : {
-        platform: process.platform,
-        arch: getHostArch(),
         ..._artifactDetails,
+        platform: _artifactDetails.platform || process.platform,
+        arch: _artifactDetails.arch || getHostArch(),
       };
   ensureIsTruthyString(artifactDetails, 'version');
   artifactDetails.version = normalizeVersion(artifactDetails.version);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -127,6 +127,22 @@ describe('Public API', () => {
       });
     });
 
+    it('should work for falsy platform/arch', async () => {
+      const path1 = await downloadArtifact({
+        version: '2.0.3',
+        artifactName: 'electron',
+      });
+
+      const path2 = await downloadArtifact({
+        version: '2.0.3',
+        artifactName: 'electron',
+        platform: undefined,
+        arch: undefined,
+      });
+
+      expect(path1).toEqual(path2);
+    });
+
     it('should work for chromedriver', async () => {
       const driverPath = await downloadArtifact({
         cacheRoot,


### PR DESCRIPTION
Currently passing `undefined` for `platform` or `arch` in options for `downloadArtifact` acts differently then if it was not a key in the object at all. This PR makes the behavior uniform whether the key is absent or the value is undefined.

This is prerequisite work to improve the install script for Electron.