### PR TITLE
build: have tsc emit Node 8-compatible JS

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2017",
     "lib": [
       "es2017"
     ],


### PR DESCRIPTION
This generates much less unnecessary code for the Node versions we're targeting.

According to https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping, ES2017 corresponds with Node 8.