### PR TITLE
fix(GotDownloader): destroy the writeStream if possible when the download errors

### DIFF
--- a/src/GotDownloader.ts
+++ b/src/GotDownloader.ts
@@ -15,7 +15,13 @@ export class GotDownloader implements Downloader<any> {
       const downloadStream = got.stream(url, options);
       downloadStream.pipe(writeStream);
 
-      downloadStream.on('error', error => reject(error));
+      downloadStream.on('error', error => {
+        if (writeStream.destroy) {
+          writeStream.destroy(error);
+        }
+
+        reject(error);
+      });
       writeStream.on('error', error => reject(error));
       writeStream.on('close', () => resolve());
     });

--- a/test/GotDownloader.network.spec.ts
+++ b/test/GotDownloader.network.spec.ts
@@ -22,9 +22,6 @@ describe('GotDownloader', () => {
     });
 
     it('should throw an error if the file does not exist', async function() {
-      if (process.platform === 'win32') {
-        return;
-      }
       const downloader = new GotDownloader();
       await withTempDirectory(async dir => {
         const testFile = path.resolve(dir, 'test.txt');


### PR DESCRIPTION
Addresses #122.
Fixes #125.

Depends on #138.