### PR TITLE
fix(GotDownloader): add URL to 404 error message

### DIFF
--- a/src/GotDownloader.ts
+++ b/src/GotDownloader.ts
@@ -16,6 +16,9 @@ export class GotDownloader implements Downloader<any> {
       downloadStream.pipe(writeStream);
 
       downloadStream.on('error', error => {
+        if (error.name === 'HTTPError' && error.statusCode === 404) {
+          error.message += ` for ${error.url}`;
+        }
         if (writeStream.destroy) {
           writeStream.destroy(error);
         }

--- a/test/GotDownloader.network.spec.ts
+++ b/test/GotDownloader.network.spec.ts
@@ -25,12 +25,10 @@ describe('GotDownloader', () => {
       const downloader = new GotDownloader();
       await withTempDirectory(async dir => {
         const testFile = path.resolve(dir, 'test.txt');
-        await expect(
-          downloader.download(
-            'https://github.com/electron/electron/releases/download/v2.0.18/bad.file',
-            testFile,
-          ),
-        ).rejects.toMatchInlineSnapshot(`[HTTPError: Response code 404 (Not Found)]`);
+        const url = 'https://github.com/electron/electron/releases/download/v2.0.18/bad.file';
+        await expect(downloader.download(url, testFile)).rejects.toMatchInlineSnapshot(
+          `[HTTPError: Response code 404 (Not Found) for ${url}]`,
+        );
       });
     });
 


### PR DESCRIPTION
This should make the issues filed about 404 errors easier to figure out.

Depends on #145.