### PR TITLE
build: publish docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Publish documentation
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch all git branches
+        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: yarn
+      - run: yarn build:docs
+      - uses: docker://malept/gha-gh-pages:1.0.2
+        with:
+          showUnderscoreFiles: true
+          versionDocs: true
+        env:
+          GH_PAGES_SSH_DEPLOY_KEY: ${{ secrets.GH_PAGES_SSH_DEPLOY_KEY }}


### PR DESCRIPTION
Attempt number 3.

Uses the same GitHub Actions workflow as Electron Packager.

### TODO (by a GitHub org admin)

* [x] Add SSH public key to repository deploy keys (read-write access)
* [x] Add `GH_PAGES_SSH_DEPLOY_KEY` (private key) to repository secrets