### PR TITLE
feat: add environment variable to override version downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ const zipFilePath = await download('4.0.4', {
 // Will download from https://mirror.example.com/electron/version-4.0.4/electron-v4.0.4-linux-x64.zip
 ```
 
+#### Using environment variables for mirror options
+Mirror options can also be specified via the following environment variables:
+* `ELECTRON_CUSTOM_DIR` - Specifies the custom directory to download from.
+* `ELECTRON_CUSTOM_FILENAME` - Specifies the custom file name to download.
+* `ELECTRON_MIRROR` - Specifies the URL of the server to download from if the version is not a nightly version.
+* `ELECTRON_NIGHTLY_MIRROR` - Specifies the URL of the server to download from if the version is a nightly version.
+
+### Overriding the version downloaded
+
+The version downloaded can be overriden by setting the `ELECTRON_CUSTOM_VERSION` environment variable.
+Setting this environment variable will override the version passed in to `download` or `downloadArtifact`.
+
 ## How It Works
 
 This module downloads Electron to a known place on your system and caches it

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,10 +76,13 @@ export async function downloadArtifact(
     }
   }
   ensureIsTruthyString(artifactDetails, 'version');
-  artifactDetails.version = normalizeVersion(artifactDetails.version);
 
+  artifactDetails.version = normalizeVersion(
+    process.env.ELECTRON_CUSTOM_VERSION || artifactDetails.version,
+  );
   const fileName = getArtifactFileName(artifactDetails);
   const url = getArtifactRemoteURL(artifactDetails);
+  console.log(`Downloading version: ${artifactDetails.version} for ${fileName} from ${url}.`);
   const cache = new Cache(artifactDetails.cacheRoot);
 
   // Do not check if the file exists in the cache when force === true
@@ -134,7 +137,7 @@ export async function downloadArtifact(
         downloader: artifactDetails.downloader,
         mirrorOptions: artifactDetails.mirrorOptions,
       });
-
+      console.log(`Checking ${shasumPath} for ${tempDownloadPath}`);
       await sumchecker('sha256', shasumPath, path.dirname(tempDownloadPath), [
         path.basename(tempDownloadPath),
       ]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,6 @@ export async function downloadArtifact(
   );
   const fileName = getArtifactFileName(artifactDetails);
   const url = getArtifactRemoteURL(artifactDetails);
-  console.log(`Downloading version: ${artifactDetails.version} for ${fileName} from ${url}.`);
   const cache = new Cache(artifactDetails.cacheRoot);
 
   // Do not check if the file exists in the cache when force === true
@@ -137,7 +136,6 @@ export async function downloadArtifact(
         downloader: artifactDetails.downloader,
         mirrorOptions: artifactDetails.mirrorOptions,
       });
-      console.log(`Checking ${shasumPath} for ${tempDownloadPath}`);
       await sumchecker('sha256', shasumPath, path.dirname(tempDownloadPath), [
         path.basename(tempDownloadPath),
       ]);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -112,6 +112,19 @@ describe('Public API', () => {
         downloadOptions: downloadOpts,
       });
     });
+
+    it('should download a custom version of a zip file', async () => {
+      process.env.ELECTRON_CUSTOM_VERSION = '2.0.10';
+      const zipPath = await download('2.0.3', {
+        cacheRoot,
+        downloader,
+      });
+      expect(typeof zipPath).toEqual('string');
+      expect(await fs.pathExists(zipPath)).toEqual(true);
+      expect(path.basename(zipPath)).toMatch(/v2.0.10/);
+      expect(path.extname(zipPath)).toEqual('.zip');
+      process.env.ELECTRON_CUSTOM_VERSION = '';
+    });
   });
 
   describe('downloadArtifact()', () => {
@@ -178,6 +191,23 @@ describe('Public API', () => {
         `"chromedriver-v2.0.9-darwin-x64.zip"`,
       );
       expect(path.extname(driverPath)).toEqual('.zip');
+    });
+
+    it('should download a custom version of a zip file', async () => {
+      process.env.ELECTRON_CUSTOM_VERSION = '2.0.10';
+      const zipPath = await downloadArtifact({
+        artifactName: 'electron',
+        cacheRoot,
+        downloader,
+        platform: process.env.npm_config_platform || process.platform,
+        arch: process.env.npm_config_arch || process.arch,
+        version: '2.0.3',
+      });
+      expect(typeof zipPath).toEqual('string');
+      expect(await fs.pathExists(zipPath)).toEqual(true);
+      expect(path.basename(zipPath)).toMatchInlineSnapshot(`"electron-v2.0.10-darwin-x64.zip"`);
+      expect(path.extname(zipPath)).toEqual('.zip');
+      process.env.ELECTRON_CUSTOM_VERSION = '';
     });
   });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -199,8 +199,8 @@ describe('Public API', () => {
         artifactName: 'electron',
         cacheRoot,
         downloader,
-        platform: process.env.npm_config_platform || process.platform,
-        arch: process.env.npm_config_arch || process.arch,
+        platform: 'darwin',
+        arch: 'x64',
         version: '2.0.3',
       });
       expect(typeof zipPath).toEqual('string');


### PR DESCRIPTION
This PR adds support for an environment variable, `ELECTRON_CUSTOM_VERSION`, that allows overriding the version downloaded.  I also added some brief documentation on the mirror environment variables that resolves #126.

One use case for this feature is to allow overriding the version of Electron specified in package.json so that CI on Electron apps can test against newer Electron versions.