### PR TITLE
feat: allow optionally only passing a base url to downloadArtifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ const zipFilePath = await downloadArtifact({
 
 ### Specifying a mirror
 
+To specify another location to download Electron assets from, the following options are
+available:
+
+* `mirrorOptions` Object
+  * `mirror` String (optional) - The base URL of the mirror to download from.
+  * `nightly_mirror` String (optional) - The Electron nightly-specific mirror URL.
+  * `customDir` String (optional) - The name of the directory to download from, often scoped by version number.
+  * `customFilename` String (optional) - The name of the asset to download.
+  * `baseOnly` Boolean (optional) - Whether or not to download from the base URL only.
+
 Anatomy of a download URL, in terms of `mirrorOptions`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ available:
   * `nightly_mirror` String (optional) - The Electron nightly-specific mirror URL.
   * `customDir` String (optional) - The name of the directory to download from, often scoped by version number.
   * `customFilename` String (optional) - The name of the asset to download.
-  * `baseOnly` Boolean (optional) - Whether or not to download from the base URL only.
+  * `baseOnly` Boolean (optional) - Whether to download from the base URL only.
 
 Anatomy of a download URL, in terms of `mirrorOptions`:
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "semantic-release": "^15.13.12",
     "ts-jest": "^24.0.0",
     "typedoc": "^0.14.2",
-    "typescript": "^3.4.5"
+    "typescript": "^3.8.0"
   },
   "lint-staged": {
     "*.ts": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier": "^1.17.1",
     "semantic-release": "^15.13.12",
     "ts-jest": "^24.0.0",
-    "typedoc": "^0.14.2",
+    "typedoc": "^0.17.2",
     "typescript": "^3.8.0"
   },
   "lint-staged": {

--- a/src/artifact-utils.ts
+++ b/src/artifact-utils.ts
@@ -24,7 +24,11 @@ export function getArtifactFileName(details: ElectronArtifactDetails) {
   ].join('-')}.zip`;
 }
 
-function mirrorVar(name: keyof MirrorOptions, options: MirrorOptions, defaultValue: string) {
+function mirrorVar(
+  name: keyof Omit<MirrorOptions, 'baseOnly'>,
+  options: MirrorOptions,
+  defaultValue: string,
+) {
   // Convert camelCase to camel_case for env var reading
   const lowerName = name.replace(/([a-z])([A-Z])/g, (_, a, b) => `${a}_${b}`).toLowerCase();
 
@@ -50,5 +54,5 @@ export function getArtifactRemoteURL(details: ElectronArtifactDetails): string {
   );
   const file = mirrorVar('customFilename', opts, getArtifactFileName(details));
 
-  return `${base}${path}/${file}`;
+  return opts.baseOnly ? `${base}` : `${base}${path}/${file}`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface MirrorOptions {
   mirror?: string;
   customDir?: string;
   customFilename?: string;
+  baseOnly?: boolean;
 }
 
 export interface ElectronDownloadRequest {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ export interface MirrorOptions {
    */
   customFilename?: string;
   /**
-   * Whether or not to download from the base URL only,
+   * Whether to download from the base URL only,
    * ignoring customDir and customFilename
    */
   baseOnly?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,9 +5,25 @@ export interface MirrorOptions {
    * The Electron nightly-specific mirror URL.
    */
   nightly_mirror?: string;
+  /**
+   * The base URL of the mirror to download from,
+   * e.g https://github.com/electron/electron/releases/download
+   */
   mirror?: string;
+  /**
+   * The name of the directory to download from,
+   * often scoped by version number e.g 'v4.0.4'
+   */
   customDir?: string;
+  /**
+   * The name of the asset to download,
+   * e.g 'electron-v4.0.4-linux-x64.zip'
+   */
   customFilename?: string;
+  /**
+   * Whether or not to download from the base URL only,
+   * ignoring customDir and customFilename
+   */
   baseOnly?: boolean;
 }
 

--- a/test/artifact-utils.spec.ts
+++ b/test/artifact-utils.spec.ts
@@ -66,6 +66,21 @@ describe('artifact-utils', () => {
       ).toMatchInlineSnapshot(`"https://mirror.example.com/v6.0.0/electron-v6.0.0-linux-x64.zip"`);
     });
 
+    it('should allow for setting only a base url when mirrorOptions.baseOnly is set', () => {
+      expect(
+        getArtifactRemoteURL({
+          arch: 'x64',
+          artifactName: 'electron',
+          mirrorOptions: {
+            mirror: 'https://mirror.example.com',
+            baseOnly: true,
+          },
+          platform: 'linux',
+          version: 'v6.0.0',
+        }),
+      ).toMatchInlineSnapshot(`"https://mirror.example.com"`);
+    });
+
     it('should replace the nightly base URL when mirrorOptions.nightly_mirror is set', () => {
       expect(
         getArtifactRemoteURL({

--- a/test/artifact-utils.spec.ts
+++ b/test/artifact-utils.spec.ts
@@ -73,6 +73,8 @@ describe('artifact-utils', () => {
           artifactName: 'electron',
           mirrorOptions: {
             mirror: 'https://mirror.example.com',
+            customDir: 'v1.2.3',
+            customFilename: 'custom-built-electron.zip',
             baseOnly: true,
           },
           platform: 'linux',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7004,10 +7004,10 @@ typescript@3.2.x:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
-typescript@^3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@^3.8.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uglify-js@^3.1.4:
   version "3.7.0"


### PR DESCRIPTION
In some cases the url passed with a mirror will be fully-formed and not have `path/name` at the end, meaning that the current logic will tack it on and cause failures. This fixes that by optionally allowing only the base url to be passed to got for download.

cc @MarshallOfSound 