### PR TITLE
fix: deprecate mirrorOptions.nightly_mirror in favor of mirrorOptions.nightlyMirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ available:
 
 * `mirrorOptions` Object
   * `mirror` String (optional) - The base URL of the mirror to download from.
-  * `nightly_mirror` String (optional) - The Electron nightly-specific mirror URL.
+  * `nightlyMirror` String (optional) - The Electron nightly-specific mirror URL.
   * `customDir` String (optional) - The name of the directory to download from, often scoped by version number.
   * `customFilename` String (optional) - The name of the asset to download.
   * `resolveAssetURL` Function (optional) - A function allowing customization of the url used to download the asset.
@@ -52,7 +52,7 @@ https://github.com/electron/electron/releases/download/v4.0.4/electron-v4.0.4-li
 |                                                     |       |                           |
 -------------------------------------------------------       -----------------------------
                         |                                                   |
-              mirror / nightly_mirror                  |    |         customFilename
+              mirror / nightlyMirror                  |    |         customFilename
                                                        ------
                                                          ||
                                                       customDir
@@ -74,7 +74,7 @@ const zipFilePath = await download('4.0.4', {
 
 const nightlyZipFilePath = await download('8.0.0-nightly.20190901', {
   mirrorOptions: {
-    nightly_mirror: 'https://nightly.example.com/',
+    nightlyMirror: 'https://nightly.example.com/',
     customDir: 'nightlies',
     customFilename: 'nightly-linux.zip'
   }

--- a/src/artifact-utils.ts
+++ b/src/artifact-utils.ts
@@ -46,7 +46,12 @@ export async function getArtifactRemoteURL(details: ElectronArtifactDetails): Pr
   const opts: MirrorOptions = details.mirrorOptions || {};
   let base = mirrorVar('mirror', opts, BASE_URL);
   if (details.version.includes('nightly')) {
-    base = mirrorVar('nightly_mirror', opts, NIGHTLY_BASE_URL);
+    if (opts.nightly_mirror) {
+      base = mirrorVar('nightly_mirror', opts, NIGHTLY_BASE_URL);
+      console.warn(`nightly_mirror is deprecated, please use nightlyMirror`);
+    } else {
+      base = mirrorVar('nightlyMirror', opts, NIGHTLY_BASE_URL);
+    }
   }
   const path = mirrorVar('customDir', opts, details.version).replace(
     '{{ version }}',

--- a/src/artifact-utils.ts
+++ b/src/artifact-utils.ts
@@ -46,8 +46,9 @@ export async function getArtifactRemoteURL(details: ElectronArtifactDetails): Pr
   const opts: MirrorOptions = details.mirrorOptions || {};
   let base = mirrorVar('mirror', opts, BASE_URL);
   if (details.version.includes('nightly')) {
-    if (opts.nightly_mirror) {
-      base = mirrorVar('nightly_mirror', opts, NIGHTLY_BASE_URL);
+    const nightlyDeprecated = mirrorVar('nightly_mirror', opts, '');
+    if (nightlyDeprecated) {
+      base = nightlyDeprecated;
       console.warn(`nightly_mirror is deprecated, please use nightlyMirror`);
     } else {
       base = mirrorVar('nightlyMirror', opts, NIGHTLY_BASE_URL);

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,9 +2,13 @@ import { Downloader } from './Downloader';
 
 export interface MirrorOptions {
   /**
-   * The Electron nightly-specific mirror URL.
+   * DEPRECATED - see nightlyMirror.
    */
   nightly_mirror?: string;
+  /**
+   * The Electron nightly-specific mirror URL.
+   */
+  nightlyMirror?: string;
   /**
    * The base URL of the mirror to download from,
    * e.g https://github.com/electron/electron/releases/download

--- a/test/artifact-utils.spec.ts
+++ b/test/artifact-utils.spec.ts
@@ -102,6 +102,23 @@ describe('artifact-utils', () => {
       );
     });
 
+    it('should replace the nightly base URL when mirrorOptions.nightly_mirror is set', async () => {
+      expect(
+        await getArtifactRemoteURL({
+          arch: 'x64',
+          artifactName: 'electron',
+          mirrorOptions: {
+            mirror: 'https://mirror.example.com/',
+            nightly_mirror: 'https://nightly.example.com/',
+          },
+          platform: 'linux',
+          version: 'v6.0.0-nightly',
+        }),
+      ).toMatchInlineSnapshot(
+        `"https://nightly.example.com/v6.0.0-nightly/electron-v6.0.0-nightly-linux-x64.zip"`,
+      );
+    });
+
     it('should replace the version dir when mirrorOptions.customDir is set', async () => {
       expect(
         await getArtifactRemoteURL({

--- a/test/artifact-utils.spec.ts
+++ b/test/artifact-utils.spec.ts
@@ -85,14 +85,14 @@ describe('artifact-utils', () => {
       ).toMatchInlineSnapshot(`"https://mirror.example.com"`);
     });
 
-    it('should replace the nightly base URL when mirrorOptions.nightly_mirror is set', async () => {
+    it('should replace the nightly base URL when mirrorOptions.nightlyMirror is set', async () => {
       expect(
         await getArtifactRemoteURL({
           arch: 'x64',
           artifactName: 'electron',
           mirrorOptions: {
             mirror: 'https://mirror.example.com/',
-            nightly_mirror: 'https://nightly.example.com/',
+            nightlyMirror: 'https://nightly.example.com/',
           },
           platform: 'linux',
           version: 'v6.0.0-nightly',


### PR DESCRIPTION
Fixes a variable inconsistency in `mirrorOptions` - all variables were camelCase except `nightly_mirror`.

cc @malept 