### PR TITLE
feat: allow custom URL resolution with resolveAssetURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ available:
   * `nightly_mirror` String (optional) - The Electron nightly-specific mirror URL.
   * `customDir` String (optional) - The name of the directory to download from, often scoped by version number.
   * `customFilename` String (optional) - The name of the asset to download.
-  * `baseOnly` Boolean (optional) - Whether to download from the base URL only.
+  * `resolveAssetURL` Function (optional) - A function allowing customization of the url used to download the asset.
 
 Anatomy of a download URL, in terms of `mirrorOptions`:
 

--- a/src/artifact-utils.ts
+++ b/src/artifact-utils.ts
@@ -25,7 +25,7 @@ export function getArtifactFileName(details: ElectronArtifactDetails) {
 }
 
 function mirrorVar(
-  name: keyof Omit<MirrorOptions, 'baseOnly'>,
+  name: keyof Omit<MirrorOptions, 'resolveAssetURL'>,
   options: MirrorOptions,
   defaultValue: string,
 ) {
@@ -54,5 +54,10 @@ export function getArtifactRemoteURL(details: ElectronArtifactDetails): string {
   );
   const file = mirrorVar('customFilename', opts, getArtifactFileName(details));
 
-  return opts.baseOnly ? `${base}` : `${base}${path}/${file}`;
+  // Allow customized download URL resolution.
+  if (opts.resolveAssetURL) {
+    return opts.resolveAssetURL(opts);
+  }
+
+  return `${base}${path}/${file}`;
 }

--- a/src/artifact-utils.ts
+++ b/src/artifact-utils.ts
@@ -42,7 +42,7 @@ function mirrorVar(
   );
 }
 
-export function getArtifactRemoteURL(details: ElectronArtifactDetails): string {
+export async function getArtifactRemoteURL(details: ElectronArtifactDetails): Promise<string> {
   const opts: MirrorOptions = details.mirrorOptions || {};
   let base = mirrorVar('mirror', opts, BASE_URL);
   if (details.version.includes('nightly')) {
@@ -56,7 +56,8 @@ export function getArtifactRemoteURL(details: ElectronArtifactDetails): string {
 
   // Allow customized download URL resolution.
   if (opts.resolveAssetURL) {
-    return opts.resolveAssetURL(opts);
+    const url = await opts.resolveAssetURL(opts);
+    return url;
   }
 
   return `${base}${path}/${file}`;

--- a/src/artifact-utils.ts
+++ b/src/artifact-utils.ts
@@ -56,7 +56,7 @@ export async function getArtifactRemoteURL(details: ElectronArtifactDetails): Pr
 
   // Allow customized download URL resolution.
   if (opts.resolveAssetURL) {
-    const url = await opts.resolveAssetURL(opts);
+    const url = await opts.resolveAssetURL(details);
     return url;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export async function downloadArtifact(
     process.env.ELECTRON_CUSTOM_VERSION || artifactDetails.version,
   );
   const fileName = getArtifactFileName(artifactDetails);
-  const url = getArtifactRemoteURL(artifactDetails);
+  const url = await getArtifactRemoteURL(artifactDetails);
   const cache = new Cache(artifactDetails.cacheRoot);
 
   // Do not check if the file exists in the cache when force === true

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface MirrorOptions {
    * A function allowing customization of the url returned
    * from getArtifactRemoteURL().
    */
-  resolveAssetURL?: (opts: Omit<MirrorOptions, 'resolveAssetURL'>) => Promise<string>;
+  resolveAssetURL?: (opts: DownloadOptions) => Promise<string>;
 }
 
 export interface ElectronDownloadRequest {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface MirrorOptions {
    * A function allowing customization of the url returned
    * from getArtifactRemoteURL().
    */
-  resolveAssetURL?: (opts: Omit<MirrorOptions, 'resolveAssetURL'>) => string;
+  resolveAssetURL?: (opts: Omit<MirrorOptions, 'resolveAssetURL'>) => Promise<string>;
 }
 
 export interface ElectronDownloadRequest {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,10 +21,10 @@ export interface MirrorOptions {
    */
   customFilename?: string;
   /**
-   * Whether to download from the base URL only,
-   * ignoring customDir and customFilename
+   * A function allowing customization of the url returned
+   * from getArtifactRemoteURL().
    */
-  baseOnly?: boolean;
+  resolveAssetURL?: (opts: Omit<MirrorOptions, 'resolveAssetURL'>) => string;
 }
 
 export interface ElectronDownloadRequest {

--- a/test/artifact-utils.spec.ts
+++ b/test/artifact-utils.spec.ts
@@ -39,9 +39,9 @@ describe('artifact-utils', () => {
   });
 
   describe('getArtifactRemoteURL', () => {
-    it('should generate a default URL correctly', () => {
+    it('should generate a default URL correctly', async () => {
       expect(
-        getArtifactRemoteURL({
+        await getArtifactRemoteURL({
           arch: 'x64',
           artifactName: 'electron',
           platform: 'linux',
@@ -52,9 +52,9 @@ describe('artifact-utils', () => {
       );
     });
 
-    it('should replace the base URL when mirrorOptions.mirror is set', () => {
+    it('should replace the base URL when mirrorOptions.mirror is set', async () => {
       expect(
-        getArtifactRemoteURL({
+        await getArtifactRemoteURL({
           arch: 'x64',
           artifactName: 'electron',
           mirrorOptions: {
@@ -66,9 +66,9 @@ describe('artifact-utils', () => {
       ).toMatchInlineSnapshot(`"https://mirror.example.com/v6.0.0/electron-v6.0.0-linux-x64.zip"`);
     });
 
-    it('should allow for custom URL resolution with mirrorOptions.resolveAssetURL', () => {
+    it('should allow for custom URL resolution with mirrorOptions.resolveAssetURL', async () => {
       expect(
-        getArtifactRemoteURL({
+        await getArtifactRemoteURL({
           arch: 'x64',
           artifactName: 'electron',
           mirrorOptions: {
@@ -85,9 +85,9 @@ describe('artifact-utils', () => {
       ).toMatchInlineSnapshot(`"https://mirror.example.com"`);
     });
 
-    it('should replace the nightly base URL when mirrorOptions.nightly_mirror is set', () => {
+    it('should replace the nightly base URL when mirrorOptions.nightly_mirror is set', async () => {
       expect(
-        getArtifactRemoteURL({
+        await getArtifactRemoteURL({
           arch: 'x64',
           artifactName: 'electron',
           mirrorOptions: {
@@ -102,9 +102,9 @@ describe('artifact-utils', () => {
       );
     });
 
-    it('should replace the version dir when mirrorOptions.customDir is set', () => {
+    it('should replace the version dir when mirrorOptions.customDir is set', async () => {
       expect(
-        getArtifactRemoteURL({
+        await getArtifactRemoteURL({
           arch: 'x64',
           artifactName: 'electron',
           mirrorOptions: {
@@ -118,9 +118,9 @@ describe('artifact-utils', () => {
       );
     });
 
-    it('should replace {{ version }} when mirrorOptions.customDir is set', () => {
+    it('should replace {{ version }} when mirrorOptions.customDir is set', async () => {
       expect(
-        getArtifactRemoteURL({
+        await getArtifactRemoteURL({
           arch: 'x64',
           artifactName: 'electron',
           mirrorOptions: {
@@ -134,9 +134,9 @@ describe('artifact-utils', () => {
       );
     });
 
-    it('should replace the filename when mirrorOptions.customFilename is set', () => {
+    it('should replace the filename when mirrorOptions.customFilename is set', async () => {
       expect(
-        getArtifactRemoteURL({
+        await getArtifactRemoteURL({
           arch: 'x64',
           artifactName: 'electron',
           mirrorOptions: {

--- a/test/artifact-utils.spec.ts
+++ b/test/artifact-utils.spec.ts
@@ -76,7 +76,7 @@ describe('artifact-utils', () => {
             customDir: 'v1.2.3',
             customFilename: 'custom-built-electron.zip',
             resolveAssetURL: opts => {
-              return opts.mirror || '';
+              return opts.mirrorOptions.mirror || '';
             },
           },
           platform: 'linux',

--- a/test/artifact-utils.spec.ts
+++ b/test/artifact-utils.spec.ts
@@ -66,7 +66,7 @@ describe('artifact-utils', () => {
       ).toMatchInlineSnapshot(`"https://mirror.example.com/v6.0.0/electron-v6.0.0-linux-x64.zip"`);
     });
 
-    it('should allow for setting only a base url when mirrorOptions.baseOnly is set', () => {
+    it('should allow for custom URL resolution with mirrorOptions.resolveAssetURL', () => {
       expect(
         getArtifactRemoteURL({
           arch: 'x64',
@@ -75,7 +75,9 @@ describe('artifact-utils', () => {
             mirror: 'https://mirror.example.com',
             customDir: 'v1.2.3',
             customFilename: 'custom-built-electron.zip',
-            baseOnly: true,
+            resolveAssetURL: opts => {
+              return opts.mirror || '';
+            },
           },
           platform: 'linux',
           version: 'v6.0.0',


### PR DESCRIPTION
Follow-up to https://github.com/electron/get/pull/156.

Refs https://github.com/electron/get/pull/156#discussion_r420974703.

Allow custom URL resolution with `resolveAssetURL`.

cc @MarshallOfSound 
