### PR TITLE
refactor: strip hash and query params from cache key

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -2,6 +2,7 @@ import debug from 'debug';
 import envPaths from 'env-paths';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import * as url from 'url';
 import * as sanitize from 'sanitize-filename';
 
 const d = debug('@electron/get:cache');
@@ -13,8 +14,11 @@ const defaultCacheRoot = envPaths('electron', {
 export class Cache {
   constructor(private cacheRoot = defaultCacheRoot) {}
 
-  private getCachePath(url: string, fileName: string): string {
-    const sanitizedUrl = sanitize(url);
+  private getCachePath(downloadUrl: string, fileName: string): string {
+    const { search, hash, ...rest } = url.parse(downloadUrl);
+    const strippedUrl = url.format(rest);
+
+    const sanitizedUrl = sanitize(strippedUrl);
     return path.resolve(this.cacheRoot, sanitizedUrl, fileName);
   }
 

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -14,7 +14,7 @@ const defaultCacheRoot = envPaths('electron', {
 export class Cache {
   constructor(private cacheRoot = defaultCacheRoot) {}
 
-  private getCachePath(downloadUrl: string, fileName: string): string {
+  public getCachePath(downloadUrl: string, fileName: string): string {
     const { search, hash, ...rest } = url.parse(downloadUrl);
     const strippedUrl = url.format(rest);
 

--- a/test/Cache.spec.ts
+++ b/test/Cache.spec.ts
@@ -19,6 +19,18 @@ describe('Cache', () => {
 
   afterEach(() => fs.remove(cacheDir));
 
+  describe('getCachePath()', () => {
+    it('should strip the hash and query params off the url', async () => {
+      const firstUrl = 'https://example.com?foo=1';
+      const secondUrl = 'https://example.com?foo=2';
+      const assetName = 'electron-v7.2.4-darwin-x64.zip-v7.2.4-darwin-x64.zip';
+
+      expect(await cache.getCachePath(firstUrl, assetName)).toEqual(
+        await cache.getCachePath(secondUrl, assetName),
+      );
+    });
+  });
+
   describe('getPathForFileInCache()', () => {
     it('should return null for a file not in the cache', async () => {
       expect(await cache.getPathForFileInCache(dummyUrl, 'test.txt')).toBeNull();


### PR DESCRIPTION
Solves an issue with cache misses caused by urls that differ in their query params by stripping hash and query params from cache key.

cc @MarshallOfSound 