### PR TITLE
build(docs): customize docs commit user & prevent CircleCI from running for gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,8 +19,11 @@ jobs:
           node-version: 12.x
       - run: yarn
       - run: yarn build:docs
-      - uses: docker://malept/gha-gh-pages:1.0.2
+      - uses: docker://malept/gha-gh-pages:1.3.0
         with:
+          gitCommitEmail: 'electron-bot@users.noreply.github.com'
+          gitCommitMessage: 'Publish [skip ci]'
+          gitCommitUser: 'Electron Bot'
           showUnderscoreFiles: true
           versionDocs: true
         env:


### PR DESCRIPTION
This should prevent the "failed to run CI on gh-pages" email notifications from CircleCI whenever there's a push to the default branch.