### PR TITLE
change way to normalizeVersion to adapt some other electron mirror site

### DIFF
--- a/src/artifact-utils.ts
+++ b/src/artifact-utils.ts
@@ -54,12 +54,10 @@ export async function getArtifactRemoteURL(details: ElectronArtifactDetails): Pr
       base = mirrorVar('nightlyMirror', opts, NIGHTLY_BASE_URL);
     }
   }
-
   const path = mirrorVar('customDir', opts, details.version).replace(
     '{{ version }}',
     details.version.replace(/^v/, ''),
   );
-  console.log('path', path, 'details.version', details.version);
   const file = mirrorVar('customFilename', opts, getArtifactFileName(details));
 
   // Allow customized download URL resolution.
@@ -68,6 +66,5 @@ export async function getArtifactRemoteURL(details: ElectronArtifactDetails): Pr
     return url;
   }
 
-  console.log('path', path, `${base}${path}/${file}`);
   return `${base}${path}/${file}`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ import { getDownloaderForSystem } from './downloader-resolver';
 import { initializeProxy } from './proxy';
 import {
   withTempDirectoryIn,
-  normalizeVersion,
   getHostArch,
   getNodeArch,
   ensureIsTruthyString,
@@ -77,9 +76,7 @@ export async function downloadArtifact(
   }
   ensureIsTruthyString(artifactDetails, 'version');
 
-  artifactDetails.version = normalizeVersion(
-    process.env.ELECTRON_CUSTOM_VERSION || artifactDetails.version,
-  );
+  artifactDetails.version = process.env.ELECTRON_CUSTOM_VERSION || artifactDetails.version;
   const fileName = getArtifactFileName(artifactDetails);
   const url = await getArtifactRemoteURL(artifactDetails);
   const cache = new Cache(artifactDetails.cacheRoot);


### PR DESCRIPTION
change way to normalizeVersion to adapt some other electron mirror site

### eg:
> mirror [https://npm.taobao.org/mirrors/electron](https://npm.taobao.org/mirrors/electron)
> mirror [https://npm.taobao.org/mirrors/chromedriver/](https://npm.taobao.org/mirrors/chromedriver/)

> [https://npm.taobao.org/mirrors/electron/11.1.1/electron-v11.1.1-win32-x64.zip](https://npm.taobao.org/mirrors/electron/11.1.1/electron-v11.1.1-win32-x64.zip)

if I set electron_mirror to https://npm.taobao.org/mirrors/electron/, it get [https://npm.taobao.org/mirrors/electron/v11.1.1/electron-v11.1.1-win32-x64.zip](https://npm.taobao.org/mirrors/electron/v11.1.1/electron-v11.1.1-win32-x64.zip) which is incorrect path.
