### PR TITLE
fix: skip checksum for versions without shasums256

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "fs-extra": "^8.1.0",
     "got": "^9.6.0",
     "progress": "^2.0.3",
+    "semver": "^6.2.0",
     "sumchecker": "^3.0.1"
   },
   "devDependencies": {
@@ -40,6 +41,7 @@
     "@types/jest": "^24.0.13",
     "@types/node": "^12.0.2",
     "@types/progress": "^2.0.3",
+    "@types/semver": "^6.2.0",
     "husky": "^2.3.0",
     "jest": "^24.8.0",
     "lint-staged": "^8.1.7",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import * as childProcess from 'child_process';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
+import * as semver from 'semver';
 
 async function useAndRemoveDirectory<T>(
   directory: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,6 @@ import * as childProcess from 'child_process';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import * as semver from 'semver';
 
 async function useAndRemoveDirectory<T>(
   directory: string,

--- a/test/fixtures/electron-v1.0.0-darwin-x64.zip
+++ b/test/fixtures/electron-v1.0.0-darwin-x64.zip
@@ -1,0 +1,1 @@
+electron-v1.0.0-darwin-x64.zip

--- a/test/fixtures/electron-v1.0.0-linux-x64.zip
+++ b/test/fixtures/electron-v1.0.0-linux-x64.zip
@@ -1,0 +1,1 @@
+electron-v1.0.0-linux-x64.zip

--- a/test/fixtures/electron-v1.0.0-win32-x64.zip
+++ b/test/fixtures/electron-v1.0.0-win32-x64.zip
@@ -1,0 +1,1 @@
+electron-v1.0.0-win32-x64.zip

--- a/test/fixtures/electron-v1.3.3-darwin-x64 copy.zip
+++ b/test/fixtures/electron-v1.3.3-darwin-x64 copy.zip
@@ -1,0 +1,1 @@
+electron-v1.3.3-darwin-x64.zip

--- a/test/fixtures/electron-v1.3.3-darwin-x64.zip
+++ b/test/fixtures/electron-v1.3.3-darwin-x64.zip
@@ -1,0 +1,1 @@
+electron-v1.3.2-darwin-x64.zip

--- a/test/fixtures/electron-v1.3.3-linux-x64 copy.zip
+++ b/test/fixtures/electron-v1.3.3-linux-x64 copy.zip
@@ -1,0 +1,1 @@
+electron-v1.3.3-linux-x64.zip

--- a/test/fixtures/electron-v1.3.3-linux-x64.zip
+++ b/test/fixtures/electron-v1.3.3-linux-x64.zip
@@ -1,0 +1,1 @@
+electron-v1.3.3-linux-x64.zip

--- a/test/fixtures/electron-v1.3.3-win32-x64 copy.zip
+++ b/test/fixtures/electron-v1.3.3-win32-x64 copy.zip
@@ -1,0 +1,1 @@
+electron-v1.3.3-win32-x64.zip

--- a/test/fixtures/electron-v1.3.3-win32-x64.zip
+++ b/test/fixtures/electron-v1.3.3-win32-x64.zip
@@ -1,0 +1,1 @@
+electron-v1.3.3-win32-x64.zip

--- a/test/fixtures/electron-v1.3.5-darwin-x64.zip
+++ b/test/fixtures/electron-v1.3.5-darwin-x64.zip
@@ -1,0 +1,1 @@
+electron-v1.3.5-darwin-x64.zip

--- a/test/fixtures/electron-v1.3.5-linux-x64.zip
+++ b/test/fixtures/electron-v1.3.5-linux-x64.zip
@@ -1,0 +1,1 @@
+electron-v1.3.5-linux-x64.zip

--- a/test/fixtures/electron-v1.3.5-win32-x64.zip
+++ b/test/fixtures/electron-v1.3.5-win32-x64.zip
@@ -1,0 +1,1 @@
+electron-v1.3.5-win32-x64.zip

--- a/yarn.lock
+++ b/yarn.lock
@@ -611,6 +611,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/semver@^6.2.0":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.2.tgz#5c27df09ca39e3c9beb4fae6b95f4d71426df0a9"
+  integrity sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -5008,7 +5013,6 @@ npm@^6.8.0:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -5023,7 +5027,6 @@ npm@^6.8.0:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -5042,14 +5045,8 @@ npm@^6.8.0:
     libnpx "^10.2.2"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -6293,7 +6290,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
Fixes #181.

Reimplementation of #25 for `@electron/get`. Adds the `semver` package to check version ranges. Note that semver@6 was used because this module still specifies Node 8.6 support.

🧪 Tests: I don't think existing tests referenced the `sumchecker` module, so I haven't added any tests. Let me know if I should!