### PR TITLE
fix: avoid long paths in cache & lower the number of folders created

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "debug": "^4.1.1",
     "env-paths": "^2.2.0",
-    "filenamify": "^4.1.0",
     "fs-extra": "^8.1.0",
     "got": "^9.6.0",
     "progress": "^2.0.3",

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -23,8 +23,7 @@ export class Cache {
     return crypto
       .createHash('sha256')
       .update(strippedUrl)
-      .digest('hex')
-      .substr(0, 10);
+      .digest('hex');
   }
 
   public getCachePath(downloadUrl: string, fileName: string): string {

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -23,7 +23,8 @@ export class Cache {
     return crypto
       .createHash('sha256')
       .update(strippedUrl)
-      .digest('hex');
+      .digest('hex')
+      .substr(0, 10);
   }
 
   public getCachePath(downloadUrl: string, fileName: string): string {

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -14,17 +14,20 @@ const defaultCacheRoot = envPaths('electron', {
 export class Cache {
   constructor(private cacheRoot = defaultCacheRoot) {}
 
-  public getCachePath(downloadUrl: string, fileName: string): string {
+  public static getCacheDirectory(downloadUrl: string): string {
     const parsedDownloadUrl = url.parse(downloadUrl);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { search, hash, ...rest } = parsedDownloadUrl;
-    const strippedUrl = url.format(rest);
-    const checksum = crypto
+    const { search, hash, pathname, ...rest } = parsedDownloadUrl;
+    const strippedUrl = url.format({ ...rest, pathname: path.dirname(pathname || 'electron') });
+
+    return crypto
       .createHash('sha256')
       .update(strippedUrl)
       .digest('hex');
+  }
 
-    return path.resolve(this.cacheRoot, checksum, fileName);
+  public getCachePath(downloadUrl: string, fileName: string): string {
+    return path.resolve(this.cacheRoot, Cache.getCacheDirectory(downloadUrl), fileName);
   }
 
   public async getPathForFileInCache(url: string, fileName: string): Promise<string | null> {

--- a/test/Cache.spec.ts
+++ b/test/Cache.spec.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
+import * as crypto from 'crypto';
 
 import { Cache } from '../src/Cache';
 
@@ -9,7 +10,10 @@ describe('Cache', () => {
   let cache: Cache;
 
   const dummyUrl = 'dummy://';
-  const sanitizedDummyUrl = 'dummy';
+  const sanitizedDummyUrl = crypto
+    .createHash('sha256')
+    .update(dummyUrl)
+    .digest('hex');
 
   beforeEach(async () => {
     cacheDir = await fs.mkdtemp(path.resolve(os.tmpdir(), 'electron-download-spec-'));

--- a/test/Cache.spec.ts
+++ b/test/Cache.spec.ts
@@ -8,7 +8,7 @@ describe('Cache', () => {
   let cache: Cache;
 
   const dummyUrl = 'dummy://dummypath';
-  const sanitizedDummyUrl = '0c57d948bd';
+  const sanitizedDummyUrl = '0c57d948bd4829db99d75c3b4a5d6836c37bc335f38012981baf5d1193b5a612';
 
   beforeEach(async () => {
     cacheDir = await fs.mkdtemp(path.resolve(os.tmpdir(), 'electron-download-spec-'));

--- a/test/Cache.spec.ts
+++ b/test/Cache.spec.ts
@@ -8,7 +8,7 @@ describe('Cache', () => {
   let cache: Cache;
 
   const dummyUrl = 'dummy://dummypath';
-  const sanitizedDummyUrl = Cache.getCacheDirectory(dummyUrl);
+  const sanitizedDummyUrl = '0c57d948bd';
 
   beforeEach(async () => {
     cacheDir = await fs.mkdtemp(path.resolve(os.tmpdir(), 'electron-download-spec-'));

--- a/test/Cache.spec.ts
+++ b/test/Cache.spec.ts
@@ -1,19 +1,14 @@
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';
-import * as crypto from 'crypto';
-
 import { Cache } from '../src/Cache';
 
 describe('Cache', () => {
   let cacheDir: string;
   let cache: Cache;
 
-  const dummyUrl = 'dummy://';
-  const sanitizedDummyUrl = crypto
-    .createHash('sha256')
-    .update(dummyUrl)
-    .digest('hex');
+  const dummyUrl = 'dummy://dummypath';
+  const sanitizedDummyUrl = Cache.getCacheDirectory(dummyUrl);
 
   beforeEach(async () => {
     cacheDir = await fs.mkdtemp(path.resolve(os.tmpdir(), 'electron-download-spec-'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,20 +2242,6 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
-filename-reserved-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
-  integrity sha1-q/c9+rc10EVECr/qLZHzieu/oik=
-
-filenamify@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/filenamify/-/filenamify-4.1.0.tgz#54d110810ae74eebfe115c1b995bd07e03cf2184"
-  integrity sha512-KQV/uJDI9VQgN7sHH1Zbk6+42cD6mnQ2HONzkXUfPJ+K2FC8GZ1dpewbbHw0Sz8Tf5k3EVdHVayM4DoAwWlmtg==
-  dependencies:
-    filename-reserved-regex "^2.0.0"
-    strip-outer "^1.0.1"
-    trim-repeated "^1.0.0"
-
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -6159,8 +6145,6 @@ rxjs@^6.3.3:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
   integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
-  dependencies:
-    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -6754,13 +6738,6 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
-strip-outer@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/strip-outer/-/strip-outer-1.0.1.tgz#b2fd2abf6604b9d1e6013057195df836b8a9d631"
-  integrity sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==
-  dependencies:
-    escape-string-regexp "^1.0.2"
-
 sumchecker@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-3.0.1.tgz#6377e996795abb0b6d348e9b3e1dfb24345a8e42"
@@ -6952,13 +6929,6 @@ trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
-
-trim-repeated@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-repeated/-/trim-repeated-1.0.0.tgz#e3646a2ea4e891312bf7eace6cfb05380bc01c21"
-  integrity sha1-42RqLqTokTEr9+rObPsFOAvAHCE=
-  dependencies:
-    escape-string-regexp "^1.0.2"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes #185 by using a checksum of the stripped URL instead of a filenamify version of it.