### PR TITLE
feat: add ability to override cache location

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ This module downloads Electron to a known place on your system and caches it
 so that future requests for that asset can be returned instantly.  The cache
 locations are:
 
+* If the environment variable `ELECTRON_GET_CACHE_DIR` is set, that path is used.
 * Linux: `$XDG_CACHE_HOME` or `~/.cache/electron/`
 * MacOS: `~/Library/Caches/electron/`
 * Windows: `%LOCALAPPDATA%/electron/Cache` or `~/AppData/Local/electron/Cache/`

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -7,9 +7,11 @@ import * as crypto from 'crypto';
 
 const d = debug('@electron/get:cache');
 
-const defaultCacheRoot = envPaths('electron', {
-  suffix: '',
-}).cache;
+const defaultCacheRoot =
+  process.env.ELECTRON_GET_CACHE_DIR ||
+  envPaths('electron', {
+    suffix: '',
+  }).cache;
 
 export class Cache {
   constructor(private cacheRoot = defaultCacheRoot) {}


### PR DESCRIPTION
I'm writing tests in another repo that inject fake downloads into the process and don't want them to pollute the real cache on my system. Also, I don't want the real cache's checksums to cause my tests to fail because they don't match the fakes' checksums.

The workflow I have in mind is that the test setup code will create a tmpdir and the set `ELECTRON_GET_CACHE_DIR` to point at that tmpdir.