### PR TITLE
feat: support hardcoded checksums

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,8 +117,14 @@ export async function downloadArtifact(
         const checksums = artifactDetails.checksums;
         if (checksums) {
           shasumPath = path.resolve(tmpDir, 'SHASUMS256.txt');
-          const generatedChecksums = Object.keys(checksums)
-            .map((fileName: string) => `${checksums[fileName]} *${fileName}`)
+          const fileNames: string[] = Object.keys(checksums);
+          if (fileNames.length === 0) {
+            throw new Error(
+              'Provided "checksums" object is empty, cannot generate a valid SHASUMS256.txt',
+            );
+          }
+          const generatedChecksums = fileNames
+            .map(fileName => `${checksums[fileName]} *${fileName}`)
             .join('\n');
           await fs.writeFile(shasumPath, generatedChecksums);
         } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,7 +64,7 @@ export interface ElectronDownloadRequestOptions {
   /**
    * Provides checksums for the artifact as strings.
    * Can be used if you already know the checksums of the Electron artifact
-   * you are downloading and want to skip the checksum file download for
+   * you are downloading and want to skip the checksum file download
    * without skipping the checksum validation.
    *
    * This should be an object whose keys are the file names of the artifacts and

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,16 @@ export interface ElectronDownloadRequestOptions {
    */
   unsafelyDisableChecksums?: boolean;
   /**
+   * Provides checksums for the artifact as strings.
+   * Can be used if you already know the checksums of the Electron artifact
+   * you are downloading and want to skip the checksum file download for
+   * without skipping the checksum validation.
+   *
+   * This should be an object whose keys are the file names of the artifacts and
+   * the values are their respective SHA256 checksums.
+   */
+  checksums?: Record<string, string>;
+  /**
    * The directory that caches Electron artifact downloads.
    *
    * The default value is dependent upon the host platform:

--- a/test/GotDownloader.network.spec.ts
+++ b/test/GotDownloader.network.spec.ts
@@ -51,7 +51,7 @@ describe('GotDownloader', () => {
         const testFile = path.resolve(dir, 'test.txt');
         await expect(
           downloader.download(
-            'https://github.com/electron/electron/releases/download/v2.0.18/bad.file',
+            'https://github.com/electron/electron/releases/download/v2.0.18/SHASUMS256.txt',
             testFile,
           ),
         ).rejects.toMatchInlineSnapshot(`"bad write error thing"`);

--- a/test/checksums.spec.ts
+++ b/test/checksums.spec.ts
@@ -37,7 +37,7 @@ describe('Hard-coded checksums', () => {
       expect(path.extname(zipPath)).toEqual('.zip');
     });
 
-    it('should be rejected with valid checksums', async () => {
+    it('should be rejected with invalid checksums', async () => {
       await expect(
         downloadArtifact({
           cacheRoot,
@@ -53,6 +53,41 @@ describe('Hard-coded checksums', () => {
         }),
       ).rejects.toMatchInlineSnapshot(
         `[Error: Generated checksum for "electron-v2.0.9-darwin-x64.zip" did not match expected checksum.]`,
+      );
+    });
+
+    it('should be rejected with an empty checksums object', async () => {
+      await expect(
+        downloadArtifact({
+          cacheRoot,
+          downloader,
+          platform: 'darwin',
+          arch: 'x64',
+          version: '2.0.9',
+          artifactName: 'electron',
+          checksums: {},
+        }),
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: Provided "checksums" object is empty, cannot generate a valid SHASUMS256.txt]`,
+      );
+    });
+
+    it('should be rejected with missing checksums', async () => {
+      await expect(
+        downloadArtifact({
+          cacheRoot,
+          downloader,
+          platform: 'darwin',
+          arch: 'x64',
+          version: '2.0.9',
+          artifactName: 'electron',
+          checksums: {
+            'electron-v2.0.9-linux-x64.zip':
+              'f28e3f9d2288af6abc31b19ca77a9241499fcd0600420197a9ff8e5e06182701',
+          },
+        }),
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: No checksum found in checksum file for "electron-v2.0.9-darwin-x64.zip".]`,
       );
     });
   });

--- a/test/checksums.spec.ts
+++ b/test/checksums.spec.ts
@@ -1,0 +1,59 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+
+import { FixtureDownloader } from './FixtureDownloader';
+import { downloadArtifact } from '../src';
+
+describe('Hard-coded checksums', () => {
+  const downloader = new FixtureDownloader();
+
+  let cacheRoot: string;
+  beforeEach(async () => {
+    cacheRoot = await fs.mkdtemp(path.resolve(os.tmpdir(), 'electron-download-spec-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(cacheRoot);
+  });
+
+  describe('download()', () => {
+    it('should succeed with valid checksums', async () => {
+      const zipPath = await downloadArtifact({
+        cacheRoot,
+        downloader,
+        platform: 'darwin',
+        arch: 'x64',
+        version: '2.0.9',
+        artifactName: 'electron',
+        checksums: {
+          'electron-v2.0.9-darwin-x64.zip':
+            'ff0bfe95bc2a351e09b959aab0bdab893cb33c203bfff83413c3f0989858c684',
+        },
+      });
+      expect(typeof zipPath).toEqual('string');
+      expect(await fs.pathExists(zipPath)).toEqual(true);
+      expect(path.extname(zipPath)).toEqual('.zip');
+    });
+
+    it('should be rejected with valid checksums', async () => {
+      await expect(
+        downloadArtifact({
+          cacheRoot,
+          downloader,
+          platform: 'darwin',
+          arch: 'x64',
+          version: '2.0.9',
+          artifactName: 'electron',
+          checksums: {
+            'electron-v2.0.9-darwin-x64.zip':
+              'f28e3f9d2288af6abc31b19ca77a9241499fcd0600420197a9ff8e5e06182701',
+          },
+        }),
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: Generated checksum for "electron-v2.0.9-darwin-x64.zip" did not match expected checksum.]`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
We want to add the checksums directly to the published NPM package.  To do so `@electron/get` needs to be able to take the hardcoded list and pass it to sumchecker.  This makes the security chain of our checksums

yarn.lock integrity --> electron npm package --> hardcoded checksums --> remote `electron` binary is validated