### PR TITLE
ci(macos): use xcode 13 since 10.2.0 has been removed from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
     <<: *steps-test
   test-mac:
     macos:
-      xcode: "10.2.0"
+      xcode: "13.0.0"
     <<: *steps-test
   test-windows:
     executor:


### PR DESCRIPTION
Fixes the CI failure in #204 