### PR TITLE
feat(proxy): support http(s)_proxy sans prefix on nodejs@>=10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ coverage
 dist
 docs
 node_modules
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ coverage
 dist
 docs
 node_modules
-.idea

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,9 @@ export function initializeProxy(): void {
 
     if (MAJOR_NODEJS_VERSION >= 10) {
       // `global-agent` works with Node.js v10 and above.
-      require('global-agent').bootstrap();
+      require('global-agent').bootstrap({
+        environmentVariableNamespace: '',
+      });
     } else {
       // `global-tunnel-ng` works with Node.js v10 and below.
       require('global-tunnel-ng').initialize();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,7 @@ export function initializeProxy(): void {
     const MAJOR_NODEJS_VERSION = parseInt(process.version.slice(1).split('.')[0], 10);
 
     if (MAJOR_NODEJS_VERSION >= 10) {
-      // See: https://github.com/electron/get/pull/214
+      // See: https://github.com/electron/get/pull/214#discussion_r798845713
       const env = getEnv('GLOBAL_AGENT_');
       process.env.GLOBAL_AGENT_HTTP_PROXY = env('HTTP_PROXY');
       process.env.GLOBAL_AGENT_HTTPS_PROXY = env('HTTPS_PROXY');

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,25 +1,7 @@
 import * as debug from 'debug';
+import { getEnv } from './utils';
 
 const d = debug('@electron/get:proxy');
-
-/**
- * get process.env variable
- * ignore case and compatible `GLOBAL_AGENT_` namespace
- */
-function getProxyEnv(name: string): string | undefined {
-  const namespace = 'GLOBAL_AGENT_';
-  const namespaceProxyName = `${namespace}${name}`;
-
-  for (const envName in process.env) {
-    if (namespaceProxyName.toLowerCase() === envName.toLowerCase()) {
-      return process.env[envName];
-    }
-
-    if (name.toLowerCase() === envName.toLowerCase()) {
-      return process.env[envName];
-    }
-  }
-}
 
 /**
  * Initializes a third-party proxy module for HTTP(S) requests.
@@ -31,9 +13,10 @@ export function initializeProxy(): void {
 
     if (MAJOR_NODEJS_VERSION >= 10) {
       // See: https://github.com/electron/get/pull/214
-      process.env.GLOBAL_AGENT_HTTP_PROXY = getProxyEnv('HTTP_PROXY');
-      process.env.GLOBAL_AGENT_HTTPS_PROXY = getProxyEnv('HTTPS_PROXY');
-      process.env.GLOBAL_AGENT_NO_PROXY = getProxyEnv('NO_PROXY');
+      const env = getEnv('GLOBAL_AGENT_');
+      process.env.GLOBAL_AGENT_HTTP_PROXY = env('HTTP_PROXY');
+      process.env.GLOBAL_AGENT_HTTPS_PROXY = env('HTTPS_PROXY');
+      process.env.GLOBAL_AGENT_NO_PROXY = env('NO_PROXY');
 
       // `global-agent` works with Node.js v10 and above.
       require('global-agent').bootstrap();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,14 +97,14 @@ export function isOfficialLinuxIA32Download(
  * Find the value of a environment variable which may or may not have the
  * prefix, in a case-insensitive manner.
  */
-export function getEnv(prefix = ''): (name: string) => EnvType[0] {
-  const envsLowerCase: EnvType = {};
+export function getEnv(prefix = ''): (name: string) => string | undefined {
+  const envsLowerCase: NodeJS.ProcessEnv = {};
 
   for (const envKey in process.env) {
     envsLowerCase[envKey.toLowerCase()] = process.env[envKey];
   }
 
-  return (name: string): EnvType[0] => {
+  return (name: string) => {
     return (
       envsLowerCase[`${prefix}${name}`.toLowerCase()] ||
       envsLowerCase[name.toLowerCase()] ||
@@ -112,5 +112,3 @@ export function getEnv(prefix = ''): (name: string) => EnvType[0] {
     );
   };
 }
-
-type EnvType = Record<string, string | undefined>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,3 +92,25 @@ export function isOfficialLinuxIA32Download(
     typeof mirrorOptions === 'undefined'
   );
 }
+
+/**
+ * Find the value of a environment variable which may or may not have the
+ * prefix, in a case-insensitive manner.
+ */
+export function getEnv(prefix = ''): (name: string) => EnvType[0] {
+  const envsLowerCase: EnvType = {};
+
+  for (const envKey in process.env) {
+    envsLowerCase[envKey.toLowerCase()] = process.env[envKey];
+  }
+
+  return (name: string): EnvType[0] => {
+    return (
+      envsLowerCase[`${prefix}${name}`.toLowerCase()] ||
+      envsLowerCase[name.toLowerCase()] ||
+      undefined
+    );
+  };
+}
+
+type EnvType = Record<string, string | undefined>;

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -174,7 +174,6 @@ describe('utils', () => {
 
     it('should return prefixed environment variable if prefixed variable found', () => {
       const env = getEnv(prefix);
-
       expect(env(envName)).toEqual(hasPrefixValue);
       expect(env(envName.toLowerCase())).toEqual(hasPrefixValue);
       expect(env(envName.toUpperCase())).toEqual(hasPrefixValue);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   getHostArch,
   ensureIsTruthyString,
   isOfficialLinuxIA32Download,
+  getEnv,
 } from '../src/utils';
 
 describe('utils', () => {
@@ -153,6 +154,43 @@ describe('utils', () => {
     it('should be false if wrong platform/arch specified', () => {
       expect(isOfficialLinuxIA32Download('win32', 'ia32', 'v4.0.0')).toEqual(false);
       expect(isOfficialLinuxIA32Download('linux', 'x64', 'v4.0.0')).toEqual(false);
+    });
+  });
+
+  describe('getEnv()', () => {
+    const [prefix, envName] = ['TeSt_EnV_vAr_', 'eNv_Key'];
+    const prefixEnvName = `${prefix}${envName}`;
+    const [hasPrefixValue, noPrefixValue] = ['yes_prefix', 'no_prefix'];
+
+    beforeAll(() => {
+      process.env[prefixEnvName] = hasPrefixValue;
+      process.env[envName] = noPrefixValue;
+    });
+
+    afterAll(() => {
+      delete process.env[prefixEnvName];
+      delete process.env[envName];
+    });
+
+    it('should return has prefix environment variable if has prefix', () => {
+      const env = getEnv(prefix);
+
+      expect(env(envName)).toEqual(hasPrefixValue);
+      expect(env(envName.toLowerCase())).toEqual(hasPrefixValue);
+      expect(env(envName.toUpperCase())).toEqual(hasPrefixValue);
+    });
+
+    it('should return non-prefix environment variable if no has prefix', () => {
+      expect(getEnv()(envName)).toEqual(noPrefixValue);
+      expect(getEnv()(envName.toLowerCase())).toEqual(noPrefixValue);
+      expect(getEnv()(envName.toUpperCase())).toEqual(noPrefixValue);
+    });
+
+    it('should return undefined if no match', () => {
+      const randomStr = 'AAAAA_electron_';
+      expect(getEnv()(randomStr)).toEqual(undefined);
+      expect(getEnv()(randomStr.toLowerCase())).toEqual(undefined);
+      expect(getEnv()(randomStr.toUpperCase())).toEqual(undefined);
     });
   });
 });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -172,7 +172,7 @@ describe('utils', () => {
       delete process.env[envName];
     });
 
-    it('should return has prefix environment variable if has prefix', () => {
+    it('should return prefixed environment variable if prefixed variable found', () => {
       const env = getEnv(prefix);
 
       expect(env(envName)).toEqual(hasPrefixValue);
@@ -180,7 +180,7 @@ describe('utils', () => {
       expect(env(envName.toUpperCase())).toEqual(hasPrefixValue);
     });
 
-    it('should return non-prefix environment variable if no has prefix', () => {
+    it('should return non-prefixed environment variable if no prefixed variable found', () => {
       expect(getEnv()(envName)).toEqual(noPrefixValue);
       expect(getEnv()(envName.toLowerCase())).toEqual(noPrefixValue);
       expect(getEnv()(envName.toUpperCase())).toEqual(noPrefixValue);


### PR DESCRIPTION
see: https://github.com/gajus/global-agent/tree/f82ad8a151af30f5bf218487d006771c6407bf89#what-is-the-reason-global-agentbootstrap-does-not-use-http_proxy



### What is the reason `global-agent/bootstrap` does not use `HTTP_PROXY`?

Some libraries (e.g. [`request`](https://npmjs.org/package/request)) change their behaviour when `HTTP_PROXY` environment variable is present. Using a namespaced environment variable prevents conflicting library behaviour.

You can override this behaviour by configuring `GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE` variable, e.g.

```bash
$ export GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE=

```

Now script initialized using `global-agent/bootstrap` will use `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables.

----

So `ELECTRON_GET_USE_PROXY` was actually not working until now...

This PR will contribute to the improvement of upstream applications, e.g: [electron-fiddle](https://github.com/electron/fiddle)

close: https://github.com/electron/fiddle/issues/258 https://github.com/electron/fiddle/issues/270

cc: @malept @erickzhao 