### PR TITLE
fix: parse proxy error

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,5 @@
 import * as debug from 'debug';
-import { getEnv } from './utils';
+import { getEnv, setEnv } from './utils';
 
 const d = debug('@electron/get:proxy');
 
@@ -14,9 +14,10 @@ export function initializeProxy(): void {
     if (MAJOR_NODEJS_VERSION >= 10) {
       // See: https://github.com/electron/get/pull/214#discussion_r798845713
       const env = getEnv('GLOBAL_AGENT_');
-      process.env.GLOBAL_AGENT_HTTP_PROXY = env('HTTP_PROXY');
-      process.env.GLOBAL_AGENT_HTTPS_PROXY = env('HTTPS_PROXY');
-      process.env.GLOBAL_AGENT_NO_PROXY = env('NO_PROXY');
+
+      setEnv('GLOBAL_AGENT_HTTP_PROXY', env('HTTP_PROXY'));
+      setEnv('GLOBAL_AGENT_HTTPS_PROXY', env('HTTPS_PROXY'));
+      setEnv('GLOBAL_AGENT_NO_PROXY', env('NO_PROXY'));
 
       // `global-agent` works with Node.js v10 and above.
       require('global-agent').bootstrap();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,7 +114,7 @@ export function getEnv(prefix = ''): (name: string) => string | undefined {
 }
 
 export function setEnv(key: string, value: string | undefined): void {
-  if (value) {
+  if (value !== void 0) {
     process.env[key] = value;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -104,11 +104,17 @@ export function getEnv(prefix = ''): (name: string) => string | undefined {
     envsLowerCase[envKey.toLowerCase()] = process.env[envKey];
   }
 
-  return (name: string) => {
+  return (name: string): string | undefined => {
     return (
       envsLowerCase[`${prefix}${name}`.toLowerCase()] ||
       envsLowerCase[name.toLowerCase()] ||
       undefined
     );
   };
+}
+
+export function setEnv(key: string, value: string | undefined): void {
+  if (value) {
+    process.env[key] = value;
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,6 +114,8 @@ export function getEnv(prefix = ''): (name: string) => string | undefined {
 }
 
 export function setEnv(key: string, value: string | undefined): void {
+  // The `void` operator always returns `undefined`.
+  // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void
   if (value !== void 0) {
     process.env[key] = value;
   }

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -199,12 +199,20 @@ describe('setEnv()', () => {
   it("doesn't set the environment variable if the value is undefined", () => {
     const [key, value] = ['Set_AAA_electron', undefined];
     setEnv(key, value);
-    expect(process.env[key]).toEqual(undefined);
+    expect(process.env[key]).toEqual(void 0);
   });
 
   it('successfully sets the environment variable when the value is defined', () => {
     const [key, value] = ['Set_BBB_electron', 'Test'];
     setEnv(key, value);
     expect(process.env[key]).toEqual(value);
+  });
+
+  it('successfully sets the environment variable when the value is falsey', () => {
+    const [key, value] = ['Set_AAA_electron', false];
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore
+    setEnv(key, value);
+    expect(process.env[key]).toEqual('false');
   });
 });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -196,13 +196,13 @@ describe('utils', () => {
 });
 
 describe('setEnv()', () => {
-  it("don't set env", () => {
+  it("doesn't set the environment variable if the value is undefined", () => {
     const [key, value] = ['Set_AAA_electron', undefined];
     setEnv(key, value);
     expect(process.env[key]).toEqual(undefined);
   });
 
-  it('success set env', () => {
+  it('successfully sets the environment variable when the value is defined', () => {
     const [key, value] = ['Set_BBB_electron', 'Test'];
     setEnv(key, value);
     expect(process.env[key]).toEqual(value);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   ensureIsTruthyString,
   isOfficialLinuxIA32Download,
   getEnv,
+  setEnv,
 } from '../src/utils';
 
 describe('utils', () => {
@@ -191,5 +192,19 @@ describe('utils', () => {
       expect(getEnv()(randomStr.toLowerCase())).toEqual(undefined);
       expect(getEnv()(randomStr.toUpperCase())).toEqual(undefined);
     });
+  });
+});
+
+describe('setEnv()', () => {
+  it("don't set env", () => {
+    const [key, value] = ['Set_AAA_electron', undefined];
+    setEnv(key, value);
+    expect(process.env[key]).toEqual(undefined);
+  });
+
+  it('success set env', () => {
+    const [key, value] = ['Set_BBB_electron', 'Test'];
+    setEnv(key, value);
+    expect(process.env[key]).toEqual(value);
   });
 });


### PR DESCRIPTION
Close: https://github.com/electron/get/issues/215

Sorry. This is a very stupid bug... 🤦‍♂️🤦‍♂️🤦‍♂️

Because:

```js
process.env.A = undefined

process.env.A === 'undefined' // => true

typeof process.env.A // => 'string'
```

cc: @malept 