### PR TITLE
fix: support npmrc for custom-version env variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as semver from 'semver';
 import * as sumchecker from 'sumchecker';
 
-import { getArtifactFileName, getArtifactRemoteURL } from './artifact-utils';
+import { getArtifactFileName, getArtifactRemoteURL, getArtifactVersion } from './artifact-utils';
 import {
   ElectronArtifactDetails,
   ElectronDownloadRequestOptions,
@@ -16,7 +16,6 @@ import { getDownloaderForSystem } from './downloader-resolver';
 import { initializeProxy } from './proxy';
 import {
   withTempDirectoryIn,
-  normalizeVersion,
   getHostArch,
   getNodeArch,
   ensureIsTruthyString,
@@ -61,9 +60,7 @@ export async function downloadArtifact(
   }
   ensureIsTruthyString(artifactDetails, 'version');
 
-  artifactDetails.version = normalizeVersion(
-    process.env.ELECTRON_CUSTOM_VERSION || artifactDetails.version,
-  );
+  artifactDetails.version = getArtifactVersion(artifactDetails);
   const fileName = getArtifactFileName(artifactDetails);
   const url = await getArtifactRemoteURL(artifactDetails);
   const cache = new Cache(artifactDetails.cacheRoot);

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,11 @@ export interface MirrorOptions {
    */
   customFilename?: string;
   /**
+   * The version of the asset to download,
+   * e.g '4.0.4'
+   */
+  customVersion?: string;
+  /**
    * A function allowing customization of the url returned
    * from getArtifactRemoteURL().
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -6040,9 +6040,9 @@ semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.3.2:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
Fixes following problems:

* It is not possible to define CUSTOM_VERSION env variable via .npmrc together with others.
* it was not picking up `customDir` and `nightlyMirror` from the `mirrorConfig` properly