### PR TITLE
fix: support npmrc for custom-version env variable

### DIFF
--- a/src/artifact-utils.ts
+++ b/src/artifact-utils.ts
@@ -33,11 +33,14 @@ function mirrorVar(
   const snakeName = name.replace(/([a-z])([A-Z])/g, (_, a, b) => `${a}_${b}`).toLowerCase();
 
   return (
-    // configs coming from .npmrc are always lowercase regardless how it was defined
+    // .npmrc
     process.env[`npm_config_electron_${name.toLowerCase()}`] ||
     process.env[`NPM_CONFIG_ELECTRON_${snakeName.toUpperCase()}`] ||
     process.env[`npm_config_electron_${snakeName}`] ||
+    // package.json
     process.env[`npm_package_config_electron_${name}`] ||
+    process.env[`npm_package_config_electron_${snakeName.toLowerCase()}`] ||
+    // env
     process.env[`ELECTRON_${snakeName.toUpperCase()}`] ||
     options[name] ||
     defaultValue
@@ -71,6 +74,6 @@ export async function getArtifactRemoteURL(details: ElectronArtifactDetails): Pr
   return `${base}${path}/${file}`;
 }
 
-export function getArtifactVersion(details: ElectronArtifactDetails) {
+export function getArtifactVersion(details: ElectronArtifactDetails): string {
   return normalizeVersion(mirrorVar('customVersion', details.mirrorOptions || {}, details.version));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as semver from 'semver';
 import * as sumchecker from 'sumchecker';
 
-import { getArtifactFileName, getArtifactRemoteURL } from './artifact-utils';
+import { getArtifactFileName, getArtifactRemoteURL, getArtifactVersion } from './artifact-utils';
 import {
   ElectronArtifactDetails,
   ElectronDownloadRequestOptions,
@@ -16,7 +16,6 @@ import { getDownloaderForSystem } from './downloader-resolver';
 import { initializeProxy } from './proxy';
 import {
   withTempDirectoryIn,
-  normalizeVersion,
   getHostArch,
   getNodeArch,
   ensureIsTruthyString,
@@ -61,9 +60,7 @@ export async function downloadArtifact(
   }
   ensureIsTruthyString(artifactDetails, 'version');
 
-  artifactDetails.version = normalizeVersion(
-    process.env.ELECTRON_CUSTOM_VERSION || artifactDetails.version,
-  );
+  artifactDetails.version = getArtifactVersion(artifactDetails);
   const fileName = getArtifactFileName(artifactDetails);
   const url = await getArtifactRemoteURL(artifactDetails);
   const cache = new Cache(artifactDetails.cacheRoot);

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,11 @@ export interface MirrorOptions {
    */
   customFilename?: string;
   /**
+   * The version of the asset to download,
+   * e.g '4.0.4'
+   */
+  customVersion?: string;
+  /**
    * A function allowing customization of the url returned
    * from getArtifactRemoteURL().
    */

--- a/test/checksums.spec.ts
+++ b/test/checksums.spec.ts
@@ -1,4 +1,3 @@
-import * as crypto from 'crypto';
 import * as fs from 'fs-extra';
 import * as os from 'os';
 import * as path from 'path';

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -215,6 +215,22 @@ describe('Public API', () => {
       process.env.ELECTRON_CUSTOM_VERSION = '';
     });
 
+    it('should download a custom version specified via mirror options', async () => {
+      const zipPath = await downloadArtifact({
+        artifactName: 'electron',
+        cacheRoot,
+        downloader,
+        platform: 'darwin',
+        arch: 'x64',
+        version: '2.0.3',
+        mirrorOptions: {
+          customVersion: '2.0.10',
+        },
+      });
+      expect(typeof zipPath).toEqual('string');
+      expect(path.basename(zipPath)).toMatchInlineSnapshot(`"electron-v2.0.10-darwin-x64.zip"`);
+    });
+
     describe('sumchecker', () => {
       beforeEach(() => {
         jest.clearAllMocks();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4269,10 +4269,12 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lru-cache@^7.4.0:
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.8.1.tgz#68ee3f4807a57d2ba185b7fd90827d5c21ce82bb"
-  integrity sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg==
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 lunr@^2.3.8:
   version "2.3.8"
@@ -6038,11 +6040,11 @@ semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.3.2:
-  version "7.3.6"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.6.tgz#5d73886fb9c0c6602e79440b97165c29581cbb2b"
-  integrity sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.7.tgz#12c5b649afdbf9049707796e22a4028814ce523f"
+  integrity sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==
   dependencies:
-    lru-cache "^7.4.0"
+    lru-cache "^6.0.0"
 
 serialize-error@^7.0.1:
   version "7.0.1"
@@ -7211,6 +7213,11 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@10.x:
   version "10.1.0"


### PR DESCRIPTION
Reopened https://github.com/electron/get/pull/219 here because CircleCi didn't want to run builds from forks

Fixes following problems:

* It is not possible to define CUSTOM_VERSION env variable via .npmrc together with others.
* it was not picking up `customDir` and `nightlyMirror` from the `mirrorConfig` properly