### PR TITLE
fix: remove global-tunnel-ng library

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,4 @@ disable, set the `ELECTRON_GET_NO_PROGRESS` environment variable to any non-empt
 ### Proxies
 
 Downstream packages should utilize the `initializeProxy` function to add HTTP(S) proxy support. If
-the environment variable `ELECTRON_GET_USE_PROXY` is set, it is called automatically. A different
-proxy module is used, depending on the version of Node in use, and as such, there are slightly
-different ways to set the proxy environment variables. For Node 10 and above,
-[`global-agent`](https://github.com/gajus/global-agent#environment-variables) is used. Otherwise,
-[`global-tunnel-ng`](https://github.com/np-maintain/global-tunnel#auto-config) is used. Refer to the
-appropriate linked module to determine how to configure proxy support.
+the environment variable `ELECTRON_GET_USE_PROXY` is set, it is called automatically.

--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
     "release"
   ],
   "optionalDependencies": {
-    "global-agent": "^3.0.0",
-    "global-tunnel-ng": "^2.7.1"
+    "global-agent": "^3.0.0"
   },
   "resolutions": {
     "eslint/inquirer": "< 7.3.0",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,23 +8,18 @@ const d = debug('@electron/get:proxy');
  */
 export function initializeProxy(): void {
   try {
-    // Code originally from https://github.com/yeoman/yo/blob/b2eea87e/lib/cli.js#L19-L28
-    const MAJOR_NODEJS_VERSION = parseInt(process.version.slice(1).split('.')[0], 10);
+    // See: https://github.com/electron/get/pull/214#discussion_r798845713
+    const env = getEnv('GLOBAL_AGENT_');
 
-    if (MAJOR_NODEJS_VERSION >= 10) {
-      // See: https://github.com/electron/get/pull/214#discussion_r798845713
-      const env = getEnv('GLOBAL_AGENT_');
+    setEnv('GLOBAL_AGENT_HTTP_PROXY', env('HTTP_PROXY'));
+    setEnv('GLOBAL_AGENT_HTTPS_PROXY', env('HTTPS_PROXY'));
+    setEnv('GLOBAL_AGENT_NO_PROXY', env('NO_PROXY'));
 
-      setEnv('GLOBAL_AGENT_HTTP_PROXY', env('HTTP_PROXY'));
-      setEnv('GLOBAL_AGENT_HTTPS_PROXY', env('HTTPS_PROXY'));
-      setEnv('GLOBAL_AGENT_NO_PROXY', env('NO_PROXY'));
-
-      // `global-agent` works with Node.js v10 and above.
-      require('global-agent').bootstrap();
-    } else {
-      // `global-tunnel-ng` works with Node.js v10 and below.
-      require('global-tunnel-ng').initialize();
-    }
+    /**
+     * TODO: replace global-agent with a hpagent. @BlackHole1
+     * https://github.com/sindresorhus/got/blob/HEAD/documentation/tips.md#proxying
+     */
+    require('global-agent').bootstrap();
   } catch (e) {
     d('Could not load either proxy modules, built-in proxy support not available:', e);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,7 +1439,7 @@ concat-stream@^1.5.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-config-chain@^1.1.11, config-chain@^1.1.12:
+config-chain@^1.1.12:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
   integrity sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==
@@ -1810,11 +1810,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-encodeurl@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
-  integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -2617,16 +2612,6 @@ global-dirs@^0.1.0:
   integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
   dependencies:
     ini "^1.3.4"
-
-global-tunnel-ng@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz#d03b5102dfde3a69914f5ee7d86761ca35d57d8f"
-  integrity sha512-4s+DyciWBV0eK148wqXxcmVAbFVPqtc3sEtUE/GTQfuU80rySLcMhUmHKSHI7/LDj8q0gDYI1lIhRRB7ieRAqg==
-  dependencies:
-    encodeurl "^1.0.2"
-    lodash "^4.17.10"
-    npm-conf "^1.1.3"
-    tunnel "^0.0.6"
 
 globals@^11.1.0:
   version "11.11.0"
@@ -4264,7 +4249,7 @@ lodash.without@~4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
+lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4722,14 +4707,6 @@ npm-cache-filename@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz#ded306c5b0bfc870a9e9faf823bc5f283e05ae11"
   integrity sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=
-
-npm-conf@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/npm-conf/-/npm-conf-1.1.3.tgz#256cc47bd0e218c259c4e9550bf413bc2192aff9"
-  integrity sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==
-  dependencies:
-    config-chain "^1.1.11"
-    pify "^3.0.0"
 
 npm-install-checks@^3.0.2:
   version "3.0.2"
@@ -6841,11 +6818,6 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
-
-tunnel@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
-  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
As of v2.0.0, the minimum nodejs version we support is 12. so `global-tunnel-ng` no longer has any effect.

cc: @malept 