### PR TITLE
feat: add environment variable GITHUB_TOKEN support.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,16 @@ export async function downloadArtifact(
     }
   }
 
+  if (process.env.GITHUB_TOKEN) {
+    artifactDetails.downloadOptions = {
+      ...artifactDetails.downloadOptions,
+      headers: {
+        ...artifactDetails.downloadOptions.headers,
+        authorization: `token ${process.env.GITHUB_TOKEN}`,
+      },
+    };
+  }
+
   if (
     !artifactDetails.isGeneric &&
     isOfficialLinuxIA32Download(


### PR DESCRIPTION
I met a trouble when I executed yarn install. 
<img width="810" alt="image" src="https://user-images.githubusercontent.com/24412720/187154247-75da4942-1d6e-417b-ae2b-7e9a48bb718c.png">
It seems like github blocked but if I add github token in request header it would get fixed.
