### PR TITLE
ci: update GitHub actions workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,16 +7,19 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
 
+permissions:
+  contents: read
+
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # tag: v3.5.3
       - name: Fetch all git branches
         run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
         with:
-          node-version: 12.x
+          node-version: 18.x
       - run: yarn --frozen-lockfile
       - run: yarn build:docs
       - uses: docker://malept/gha-gh-pages:1.3.0

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,19 +1,25 @@
 name: "Check Semantic Commit"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   main:
+    permissions:
+      pull-requests: read  # for amannn/action-semantic-pull-request to analyze PRs
+      statuses: write  # for amannn/action-semantic-pull-request to mark status of analyzed PR
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
       - name: semantic-pull-request
-        uses: amannn/action-semantic-pull-request@v4
+        uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54 # v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
* Updates and pins SHAs for actions
* Restricts permissions for actions
* Bump Node.js version on docs workflow to v18 to clear deprecation warning