### PR TITLE
ci: fix publish documentation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,27 +7,28 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9  # tag: v3.5.3
       - name: Fetch all git branches
         run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-      - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c  # tag: v3.6.0
+      - uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381  # tag: v3.8.0
         with:
           node-version: 18.x
       - run: yarn --frozen-lockfile
       - run: yarn build:docs
-      - uses: docker://malept/gha-gh-pages:1.3.0
+      - uses: dsanders11/github-action-gh-pages@6837fa66857ff3234e3ea5bcf709c86767ae3ce1
         with:
-          gitCommitEmail: 'electron-bot@users.noreply.github.com'
+          gitCommitEmail: 'github-actions@github.com'
           gitCommitMessage: 'Publish [skip ci]'
-          gitCommitUser: 'Electron Bot'
+          gitCommitUser: 'github-actions'
           showUnderscoreFiles: true
           versionDocs: true
         env:
-          GH_PAGES_SSH_DEPLOY_KEY: ${{ secrets.GH_PAGES_SSH_DEPLOY_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 18.x
       - run: yarn --frozen-lockfile
       - run: yarn build:docs
-      - uses: dsanders11/github-action-gh-pages@6837fa66857ff3234e3ea5bcf709c86767ae3ce1
+      - uses: malept/github-action-gh-pages@e151760357583e2f9152f8e8c8658ceb3ccf3d64  # tag: v1.3.1
         with:
           gitCommitEmail: 'github-actions@github.com'
           gitCommitMessage: 'Publish [skip ci]'


### PR DESCRIPTION
Same changes as https://github.com/electron/electron-packager/pull/1547 plus bumping the version of `actions/setup-node`.