### PR TITLE
docs: [[ target ]] -> {@link target}

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -95,8 +95,8 @@ export interface ElectronDownloadRequestOptions {
    */
   mirrorOptions?: MirrorOptions;
   /**
-   * The custom [[Downloader]] class used to download artifacts. Defaults to the
-   * built-in [[GotDownloader]].
+   * The custom {@link Downloader} class used to download artifacts. Defaults to the
+   * built-in {@link GotDownloader}.
    */
   downloader?: Downloader<DownloadOptions>;
   /**


### PR DESCRIPTION
Uses `@link` notation to link to the target API: https://tsdoc.org/pages/tags/link/

For TypeDoc, this was deprecated in v0.23.0 and removed in v0.24.0: https://typedoc.org/guides/changelog/