### PR TITLE
ci: update publish documentation default branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,7 @@ jobs:
       - run: yarn build:docs
       - uses: malept/github-action-gh-pages@e151760357583e2f9152f8e8c8658ceb3ccf3d64  # tag: v1.3.1
         with:
+          defaultBranch: main
           gitCommitEmail: 'github-actions@github.com'
           gitCommitMessage: 'Publish [skip ci]'
           gitCommitUser: 'github-actions'


### PR DESCRIPTION
Follow-up to #254, looks like this was still defaulting to `master` when we need it to point to `main`.