### PR TITLE
feat: cacheMode option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,17 +204,17 @@ export async function downloadArtifact(
   }
 
   return await withTempDirectoryIn(
-    artifactDetails.tempDirectory,
+    details.tempDirectory,
     async tempFolder => {
       const tempDownloadPath = path.resolve(tempFolder, getArtifactFileName(details));
 
-      const downloader = artifactDetails.downloader || (await getDownloaderForSystem());
+      const downloader = details.downloader || (await getDownloaderForSystem());
       d(
         `Downloading ${url} to ${tempDownloadPath} with options: ${JSON.stringify(
-          artifactDetails.downloadOptions,
+          details.downloadOptions,
         )}`,
       );
-      await downloader.download(url, tempDownloadPath, artifactDetails.downloadOptions);
+      await downloader.download(url, tempDownloadPath, details.downloadOptions);
 
       await validateArtifact(details, tempDownloadPath, downloadArtifact);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
   doesCallerOwnTemporaryOutput,
   effectiveCacheMode,
   shouldTryReadCache,
+  TempDirCleanUpMode,
 } from './utils';
 
 export { getHostArch } from './utils';
@@ -113,7 +114,9 @@ async function validateArtifact(
         }
       }
     },
-    !doesCallerOwnTemporaryOutput(effectiveCacheMode(artifactDetails)),
+    doesCallerOwnTemporaryOutput(effectiveCacheMode(artifactDetails))
+      ? TempDirCleanUpMode.ORPHAN
+      : TempDirCleanUpMode.CLEAN,
   );
 }
 
@@ -221,7 +224,7 @@ export async function downloadArtifact(
         return await cache.putFileInCache(url, tempDownloadPath, fileName);
       }
     },
-    !doesCallerOwnTemporaryOutput(cacheMode),
+    doesCallerOwnTemporaryOutput(cacheMode) ? TempDirCleanUpMode.ORPHAN : TempDirCleanUpMode.CLEAN,
   );
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,28 @@ export interface ElectronDownloadRequest {
   artifactName: string;
 }
 
+export enum ElectronDownloadCacheMode {
+  /**
+   * Reads from the cache if present
+   * Writes to the cache after fetch if not present
+   */
+  ReadWrite,
+  /**
+   * Reads from the cache if present
+   * Will **not** write back to the cache after fetching missing artifact
+   */
+  ReadOnly,
+  /**
+   * Skips reading from the cache
+   * Will write back into the cache, overwriting anything currently in the cache after fetch
+   */
+  WriteOnly,
+  /**
+   * Bypasses the cache completely, neither reads from nor writes to the cache
+   */
+  Bypass,
+}
+
 /**
  * @category Download Electron
  */
@@ -90,6 +112,7 @@ export interface ElectronDownloadRequestOptions {
    * Whether to download an artifact regardless of whether it's in the cache directory.
    *
    * @defaultValue `false`
+   * @deprecated This option is depracated and directly maps to `cacheMode: ElectronDownloadCacheMode.WriteOnly`
    */
   force?: boolean;
   /**
@@ -149,12 +172,11 @@ export interface ElectronDownloadRequestOptions {
    */
   tempDirectory?: string;
   /**
-   * When set to `true`, do not put the downloaded artifact into the cache, leaving it
-   * in the temporary directory. You need to clean up the temporary directory yourself.
+   * Controls the cache read and write behavior.
    *
-   * Defaults to `false`.
+   * Defaults to `ElectronDownloadCacheMode.ReadWrite`.
    */
-  dontCache?: boolean;
+  cacheMode?: ElectronDownloadCacheMode;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,13 @@ export interface ElectronDownloadRequestOptions {
    * It is used before artifacts are put into cache.
    */
   tempDirectory?: string;
+  /**
+   * When set to `true`, do not put the downloaded artifact into the cache, leaving if
+   * in the temporary directory. You need to clean up the temporary directory yourself.
+   *
+   * Defaults to `false`.
+   */
+  dontCache?: boolean;
 }
 
 export type ElectronPlatformArtifactDetails = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,7 +112,7 @@ export interface ElectronDownloadRequestOptions {
    * Whether to download an artifact regardless of whether it's in the cache directory.
    *
    * @defaultValue `false`
-   * @deprecated This option is deprecated and directly maps to `cacheMode: ElectronDownloadCacheMode.WriteOnly`
+   * @deprecated This option is deprecated and directly maps to {@link cacheMode | `cacheMode: ElectronDownloadCacheMode.WriteOnly`}
    */
   force?: boolean;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,17 +174,20 @@ export interface ElectronDownloadRequestOptions {
   /**
    * Controls the cache read and write behavior.
    *
-   * When set to either `ReadOnly` or `Bypass` the caller is responsible
-   * for cleaning up the returned file path once they are done using
-   * it. E.g. `fs.remove(path.dirname(pathFromElectronGet))`
+   * When set to either {@link ElectronDownloadCacheMode.ReadOnly | ReadOnly} or
+   * {@link ElectronDownloadCacheMode.Bypass | Bypass}, the caller is responsible
+   * for cleaning up the returned file path once they are done using it
+   * (e.g. via `fs.remove(path.dirname(pathFromElectronGet))`).
    *
-   * When set to either `WriteOnly` or `ReadWrite` (the default) the caller
+   * When set to either {@link ElectronDownloadCacheMode.WriteOnly | WriteOnly} or
+   * {@link ElectronDownloadCacheMode.ReadWrite | ReadWrite} (the default), the caller
    * should not move or delete the file path that is returned as the path
    * points directly to the disk cache.
    *
-   * Defaults to `ElectronDownloadCacheMode.ReadWrite`.
+   * This option cannot be used in conjunction with {@link ElectronDownloadRequestOptions.force}.
+   *
+   * @defaultValue {@link ElectronDownloadCacheMode.ReadWrite}
    */
-  cacheMode?: ElectronDownloadCacheMode;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,7 @@ export interface ElectronDownloadRequestOptions {
    *
    * @defaultValue {@link ElectronDownloadCacheMode.ReadWrite}
    */
+  cacheMode?: ElectronDownloadCacheMode;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -174,6 +174,14 @@ export interface ElectronDownloadRequestOptions {
   /**
    * Controls the cache read and write behavior.
    *
+   * When set to either `ReadOnly` or `Bypass` the caller is responsible
+   * for cleaning up the returned file path once they are done using
+   * it. E.g. `fs.remove(path.dirname(pathFromElectronGet))`
+   *
+   * When set to either `WriteOnly` or `ReadWrite` (the default) the caller
+   * should not move or delete the file path that is returned as the path
+   * points directly to the disk cache.
+   *
    * Defaults to `ElectronDownloadCacheMode.ReadWrite`.
    */
   cacheMode?: ElectronDownloadCacheMode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,7 +112,7 @@ export interface ElectronDownloadRequestOptions {
    * Whether to download an artifact regardless of whether it's in the cache directory.
    *
    * @defaultValue `false`
-   * @deprecated This option is depracated and directly maps to `cacheMode: ElectronDownloadCacheMode.WriteOnly`
+   * @deprecated This option is deprecated and directly maps to `cacheMode: ElectronDownloadCacheMode.WriteOnly`
    */
   force?: boolean;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export interface ElectronDownloadRequestOptions {
    */
   tempDirectory?: string;
   /**
-   * When set to `true`, do not put the downloaded artifact into the cache, leaving if
+   * When set to `true`, do not put the downloaded artifact into the cache, leaving it
    * in the temporary directory. You need to clean up the temporary directory yourself.
    *
    * Defaults to `false`.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -154,7 +154,7 @@ export function effectiveCacheMode(
         'Setting both "force" and "cacheMode" is not supported, please exclusively use "cacheMode"',
       );
     }
-    return ElectronDownloadCacheMode.ReadWrite;
+    return ElectronDownloadCacheMode.WriteOnly;
   }
 
   return artifactDetails.cacheMode || ElectronDownloadCacheMode.ReadWrite;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,13 +26,18 @@ export async function mkdtemp(parentDirectory: string = os.tmpdir()): Promise<st
   return await fs.mkdtemp(path.resolve(parentDirectory, tempDirectoryPrefix));
 }
 
+export enum TempDirCleanUpMode {
+  CLEAN,
+  ORPHAN,
+}
+
 export async function withTempDirectoryIn<T>(
   parentDirectory: string = os.tmpdir(),
   fn: (directory: string) => Promise<T>,
-  removeAfter?: boolean,
+  cleanUp: TempDirCleanUpMode,
 ): Promise<T> {
   const tempDirectory = await mkdtemp(parentDirectory);
-  if (removeAfter === undefined ? true : removeAfter) {
+  if (cleanUp === TempDirCleanUpMode.CLEAN) {
     return useAndRemoveDirectory(tempDirectory, fn);
   } else {
     return fn(tempDirectory);
@@ -41,9 +46,9 @@ export async function withTempDirectoryIn<T>(
 
 export async function withTempDirectory<T>(
   fn: (directory: string) => Promise<T>,
-  removeAfter?: boolean,
+  cleanUp: TempDirCleanUpMode,
 ): Promise<T> {
-  return withTempDirectoryIn(undefined, fn, removeAfter);
+  return withTempDirectoryIn(undefined, fn, cleanUp);
 }
 
 export function normalizeVersion(version: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,17 +16,29 @@ async function useAndRemoveDirectory<T>(
   return result;
 }
 
+export async function mkdtemp(parentDirectory: string = os.tmpdir()): Promise<string> {
+  const tempDirectoryPrefix = 'electron-download-';
+  return await fs.mkdtemp(path.resolve(parentDirectory, tempDirectoryPrefix));
+}
+
 export async function withTempDirectoryIn<T>(
   parentDirectory: string = os.tmpdir(),
   fn: (directory: string) => Promise<T>,
+  removeAfter?: boolean,
 ): Promise<T> {
-  const tempDirectoryPrefix = 'electron-download-';
-  const tempDirectory = await fs.mkdtemp(path.resolve(parentDirectory, tempDirectoryPrefix));
-  return useAndRemoveDirectory(tempDirectory, fn);
+  const tempDirectory = await mkdtemp(parentDirectory);
+  if (removeAfter === undefined ? true : removeAfter) {
+    return useAndRemoveDirectory(tempDirectory, fn);
+  } else {
+    return fn(tempDirectory);
+  }
 }
 
-export async function withTempDirectory<T>(fn: (directory: string) => Promise<T>): Promise<T> {
-  return withTempDirectoryIn(undefined, fn);
+export async function withTempDirectory<T>(
+  fn: (directory: string) => Promise<T>,
+  removeAfter?: boolean,
+): Promise<T> {
+  return withTempDirectoryIn(undefined, fn, removeAfter);
 }
 
 export function normalizeVersion(version: string): string {

--- a/test/GotDownloader.network.spec.ts
+++ b/test/GotDownloader.network.spec.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs-extra';
 import * as path from 'path';
 
 import { GotDownloader } from '../src/GotDownloader';
-import { withTempDirectory } from '../src/utils';
+import { TempDirCleanUpMode, withTempDirectory } from '../src/utils';
 import { EventEmitter } from 'events';
 
 describe('GotDownloader', () => {
@@ -26,7 +26,7 @@ describe('GotDownloader', () => {
         expect(await fs.pathExists(testFile)).toEqual(true);
         expect(await fs.readFile(testFile, 'utf8')).toMatchSnapshot();
         expect(progressCallbackCalled).toEqual(true);
-      });
+      }, TempDirCleanUpMode.CLEAN);
     });
 
     it('should throw an error if the file does not exist', async function() {
@@ -36,7 +36,7 @@ describe('GotDownloader', () => {
         const url = 'https://github.com/electron/electron/releases/download/v2.0.18/bad.file';
         const snapshot = `[HTTPError: Response code 404 (Not Found) for ${url}]`;
         await expect(downloader.download(url, testFile)).rejects.toMatchInlineSnapshot(snapshot);
-      });
+      }, TempDirCleanUpMode.CLEAN);
     });
 
     it('should throw an error if the file write stream fails', async () => {
@@ -55,7 +55,7 @@ describe('GotDownloader', () => {
             testFile,
           ),
         ).rejects.toMatchInlineSnapshot(`"bad write error thing"`);
-      });
+      }, TempDirCleanUpMode.CLEAN);
     });
 
     it('should download to a deep uncreated path', async () => {
@@ -71,7 +71,7 @@ describe('GotDownloader', () => {
         ).resolves.toBeUndefined();
         expect(await fs.pathExists(testFile)).toEqual(true);
         expect(await fs.readFile(testFile, 'utf8')).toMatchSnapshot();
-      });
+      }, TempDirCleanUpMode.CLEAN);
     });
   });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 
 import { FixtureDownloader } from './FixtureDownloader';
 import { download, downloadArtifact } from '../src';
-import { DownloadOptions } from '../src/types';
+import { DownloadOptions, ElectronDownloadCacheMode } from '../src/types';
 import * as sumchecker from 'sumchecker';
 
 jest.mock('sumchecker');
@@ -132,11 +132,11 @@ describe('Public API', () => {
       process.env.ELECTRON_CUSTOM_VERSION = '';
     });
 
-    it('should not put artifact in cache when dontCache=true', async () => {
+    it('should not put artifact in cache when cacheMode=ReadOnly', async () => {
       const zipPath = await download('2.0.10', {
         cacheRoot,
         downloader,
-        dontCache: true,
+        cacheMode: ElectronDownloadCacheMode.ReadOnly,
       });
       expect(typeof zipPath).toEqual('string');
       expect(await fs.pathExists(zipPath)).toEqual(true);
@@ -145,7 +145,7 @@ describe('Public API', () => {
       expect(fs.readdirSync(cacheRoot).length).toEqual(0);
     });
 
-    it('should use cache hits when dontCache=true', async () => {
+    it('should use cache hits when cacheMode=ReadOnly', async () => {
       const zipPath = await download('2.0.9', {
         cacheRoot,
         downloader,
@@ -154,7 +154,7 @@ describe('Public API', () => {
       const zipPath2 = await download('2.0.9', {
         cacheRoot,
         downloader,
-        dontCache: true,
+        cacheMode: ElectronDownloadCacheMode.ReadOnly,
       });
       expect(zipPath2).not.toEqual(zipPath);
       expect(path.dirname(zipPath2).startsWith(cacheRoot)).toEqual(false);
@@ -264,7 +264,7 @@ describe('Public API', () => {
       expect(path.basename(zipPath)).toMatchInlineSnapshot(`"electron-v2.0.10-darwin-x64.zip"`);
     });
 
-    it('should not put artifact in cache when dontCache=true', async () => {
+    it('should not put artifact in cache when cacheMode=ReadOnly', async () => {
       const driverPath = await downloadArtifact({
         cacheRoot,
         downloader,
@@ -272,7 +272,7 @@ describe('Public API', () => {
         artifactName: 'chromedriver',
         platform: 'darwin',
         arch: 'x64',
-        dontCache: true,
+        cacheMode: ElectronDownloadCacheMode.ReadOnly,
       });
       expect(await fs.pathExists(driverPath)).toEqual(true);
       expect(path.basename(driverPath)).toMatchInlineSnapshot(
@@ -283,7 +283,7 @@ describe('Public API', () => {
       expect(fs.readdirSync(cacheRoot).length).toEqual(0);
     });
 
-    it('should use cache hits when dontCache=true', async () => {
+    it('should use cache hits when cacheMode=ReadOnly', async () => {
       const driverPath = await downloadArtifact({
         cacheRoot,
         downloader,
@@ -300,7 +300,7 @@ describe('Public API', () => {
         artifactName: 'chromedriver',
         platform: 'darwin',
         arch: 'x64',
-        dontCache: true,
+        cacheMode: ElectronDownloadCacheMode.ReadOnly,
       });
       expect(driverPath2).not.toEqual(driverPath);
       expect(path.dirname(driverPath2).startsWith(cacheRoot)).toEqual(false);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -9,6 +9,7 @@ import {
   isOfficialLinuxIA32Download,
   getEnv,
   setEnv,
+  TempDirCleanUpMode,
 } from '../src/utils';
 
 describe('utils', () => {
@@ -39,17 +40,17 @@ describe('utils', () => {
       await withTempDirectory(async dir => {
         expect(await fs.pathExists(dir)).toEqual(true);
         expect(await fs.readdir(dir)).toEqual([]);
-      });
+      }, TempDirCleanUpMode.CLEAN);
     });
 
     it('should return the value the function returns', async () => {
-      expect(await withTempDirectory(async () => 1234)).toEqual(1234);
+      expect(await withTempDirectory(async () => 1234, TempDirCleanUpMode.CLEAN)).toEqual(1234);
     });
 
     it('should delete the directory when the function terminates', async () => {
       const mDir = await withTempDirectory(async dir => {
         return dir;
-      });
+      }, TempDirCleanUpMode.CLEAN);
       expect(mDir).not.toBeUndefined();
       expect(await fs.pathExists(mDir)).toEqual(false);
     });
@@ -60,17 +61,17 @@ describe('utils', () => {
         withTempDirectory(async dir => {
           mDir = dir;
           throw 'my error';
-        }),
+        }, TempDirCleanUpMode.CLEAN),
       ).rejects.toEqual('my error');
       expect(mDir).not.toBeUndefined();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(await fs.pathExists(mDir!)).toEqual(false);
     });
 
-    it('should not delete the directory if removeAfter is false', async () => {
+    it('should not delete the directory if told to orphan the temp dir', async () => {
       const mDir = await withTempDirectory(async dir => {
         return dir;
-      }, false);
+      }, TempDirCleanUpMode.ORPHAN);
       expect(mDir).not.toBeUndefined();
       try {
         expect(await fs.pathExists(mDir)).toEqual(true);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -47,13 +47,11 @@ describe('utils', () => {
     });
 
     it('should delete the directory when the function terminates', async () => {
-      let mDir: string | undefined = undefined;
-      await withTempDirectory(async dir => {
-        mDir = dir;
+      const mDir = await withTempDirectory(async dir => {
+        return dir;
       });
       expect(mDir).not.toBeUndefined();
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(await fs.pathExists(mDir!)).toEqual(false);
+      expect(await fs.pathExists(mDir)).toEqual(false);
     });
 
     it('should delete the directory and reject correctly even if the function throws', async () => {
@@ -67,6 +65,18 @@ describe('utils', () => {
       expect(mDir).not.toBeUndefined();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(await fs.pathExists(mDir!)).toEqual(false);
+    });
+
+    it('should not delete the directory if removeAfter is false', async () => {
+      const mDir = await withTempDirectory(async dir => {
+        return dir;
+      }, false);
+      expect(mDir).not.toBeUndefined();
+      try {
+        expect(await fs.pathExists(mDir)).toEqual(true);
+      } finally {
+        await fs.remove(mDir);
+      }
     });
   });
 


### PR DESCRIPTION
Closes #209. This is less of a problem these days as `@electron/fiddle-core` actually steals the file out of the cache, so there's not duplicate copies, but that's not optimal behavior, and leaves behind `SHASUMS256.txt` files in the cache unnecessarily. So, provide an option to not add the downloaded file to the cache.

Closes electron/packager#1552