### PR TITLE
docs: add API docs to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 ## Usage
 
+For full API detail, see the [API documentation](https://electron.github.io/get/).
+
 ### Simple: Downloading an Electron Binary ZIP
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-For full API detail, see the [API documentation](https://electron.github.io/get/).
+For full API details, see the [API documentation](https://electron.github.io/get/).
 
 ### Simple: Downloading an Electron Binary ZIP
 


### PR DESCRIPTION
this is funny but we've added TypeDoc documentation for the last 5 years but never linked it from the README.

ref https://github.com/electron/get/pull/93