### PR TITLE
chore: minor eslint and type fixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,6 @@ import {
   getNodeArch,
   ensureIsTruthyString,
   isOfficialLinuxIA32Download,
-  withTempDirectory,
 } from './utils';
 
 export { getHostArch } from './utils';
@@ -41,7 +40,7 @@ async function validateArtifact(
   artifactDetails: ElectronArtifactDetails,
   downloadedAssetPath: string,
   _downloadArtifact: ArtifactDownloader,
-) {
+): Promise<void> {
   return await withTempDirectoryIn(artifactDetails.tempDirectory, async tempFolder => {
     // Don't try to verify the hash of the hash file itself
     // and for older versions that don't have a SHASUMS256.txt

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,8 +137,6 @@ export type ElectronArtifactDetails =
   | ElectronPlatformArtifactDetails
   | ElectronGenericArtifactDetails;
 
-export type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
-
 export type ElectronPlatformArtifactDetailsWithDefaults =
   | (Omit<ElectronPlatformArtifactDetails, 'platform' | 'arch'> & {
       platform?: string;


### PR DESCRIPTION
* Fixes all `npm run lint` errors.
* The `Omit` utility type was added into TypeScript 3.5, so we don't need to define our own helper.