### PR TITLE
fix: eliminate race condition in cache for SHASUMS256

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -39,20 +39,10 @@ export class Cache {
     return null;
   }
 
-  public async putFileInCache(
-    url: string,
-    currentPath: string,
-    fileName: string,
-    overwrite?: boolean,
-  ): Promise<string> {
+  public async putFileInCache(url: string, currentPath: string, fileName: string): Promise<string> {
     const cachePath = this.getCachePath(url, fileName);
     d(`Moving ${currentPath} to ${cachePath}`);
-    if (await fs.pathExists(cachePath)) {
-      d('* Replacing existing file');
-      await fs.remove(cachePath);
-    }
-
-    await fs.move(currentPath, cachePath, { overwrite });
+    await fs.move(currentPath, cachePath, { overwrite: true });
 
     return cachePath;
   }

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -39,7 +39,12 @@ export class Cache {
     return null;
   }
 
-  public async putFileInCache(url: string, currentPath: string, fileName: string): Promise<string> {
+  public async putFileInCache(
+    url: string,
+    currentPath: string,
+    fileName: string,
+    overwrite?: boolean,
+  ): Promise<string> {
     const cachePath = this.getCachePath(url, fileName);
     d(`Moving ${currentPath} to ${cachePath}`);
     if (await fs.pathExists(cachePath)) {
@@ -47,7 +52,7 @@ export class Cache {
       await fs.remove(cachePath);
     }
 
-    await fs.move(currentPath, cachePath);
+    await fs.move(currentPath, cachePath, { overwrite });
 
     return cachePath;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,12 @@ export async function downloadArtifact(
 
     await validateArtifact(details, tempDownloadPath, downloadArtifact);
 
-    return await cache.putFileInCache(url, tempDownloadPath, fileName);
+    return await cache.putFileInCache(
+      url,
+      tempDownloadPath,
+      fileName,
+      details.artifactName.startsWith('SHASUMS256'), // overwrite the SHASUMS in the cache
+    );
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,12 +180,7 @@ export async function downloadArtifact(
 
     await validateArtifact(details, tempDownloadPath, downloadArtifact);
 
-    return await cache.putFileInCache(
-      url,
-      tempDownloadPath,
-      fileName,
-      details.artifactName.startsWith('SHASUMS256'), // overwrite the SHASUMS in the cache
-    );
+    return await cache.putFileInCache(url, tempDownloadPath, fileName);
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/electron/packager/issues/1552

When downloading the same version across multiple architectures at once (e.g. for a Universal macOS build), it's possible for `fs.move` to run into a race condition because the same SHASUMS256 file is being written to the cache for each arch.

@dsanders11 kindly pointed out that the code we have in `putFileInCache` is trying to mimic the `overwrite` option in `fs.move`, but follows an [antipattern in Node.js](https://nodejs.org/api/fs.html#fsexistspath-callback):

> Using fs.exists() to check for the existence of a file before calling fs.open(), fs.readFile(), or fs.writeFile() is not recommended. Doing so introduces a race condition, since other processes may change the file’s state between the two calls. Instead, user code should open/read/write the file directly and handle the error raised if the file does not exist.
