### PR TITLE
fix: cache works properly when /tmp is on a separate file system

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -49,7 +49,9 @@ export class Cache {
       d('* Replacing existing file');
       await fs.promises.rm(cachePath, { recursive: true, force: true });
     }
-    await fs.promises.rename(currentPath, cachePath);
+
+    await fs.promises.copyFile(currentPath, cachePath);
+    await fs.promises.rm(currentPath);
 
     return cachePath;
   }


### PR DESCRIPTION
Fix for https://github.com/electron/get/issues/332.

When `/tmp` is on a different file system than the cache, `fs.promises.rename` will throw an error in linux.

This change uses `copyFile` and `rm` rather than `rename`, and introduces a unit test to verify that `putFileInCache` still succeeds if `rename` throws an error.