### PR TITLE
fix: avoid permission errors on windows during double-installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,6 @@
   ],
   "optionalDependencies": {
     "global-agent": "^3.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -61,7 +61,7 @@ export class Cache {
           ]);
           if (existingHash !== currentHash) {
             d('* Replacing existing file as it does not match our inbound file');
-            fs.promises.rm(cachePath, { recursive: true, force: true });
+            await fs.promises.rm(cachePath, { recursive: true, force: true });
           } else {
             d('* Using existing file as the hash matches our inbound file, no need to replace');
             return cachePath;

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -4,6 +4,7 @@ import fs from 'graceful-fs';
 
 import crypto from 'node:crypto';
 import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 import url from 'node:url';
 
 const d = debug('@electron/get:cache');
@@ -37,35 +38,71 @@ export class Cache {
     return null;
   }
 
+  private async hashFile(path: string): Promise<string> {
+    const hasher = crypto.createHash('sha256');
+    await pipeline(fs.createReadStream(path), hasher);
+    return hasher.digest('hex');
+  }
+
   public async putFileInCache(url: string, currentPath: string, fileName: string): Promise<string> {
-    const cachePath = this.getCachePath(url, fileName);
-    d(`Moving ${currentPath} to ${cachePath}`);
+    const attempt = async (attemptsLeft = 3): Promise<string> => {
+      try {
+        const cachePath = this.getCachePath(url, fileName);
+        d(`Moving ${currentPath} to ${cachePath}`);
 
-    if (!fs.existsSync(path.dirname(cachePath))) {
-      await fs.promises.mkdir(path.dirname(cachePath), { recursive: true });
-    }
+        if (!fs.existsSync(path.dirname(cachePath))) {
+          await fs.promises.mkdir(path.dirname(cachePath), { recursive: true });
+        }
 
-    if (fs.existsSync(cachePath)) {
-      d('* Replacing existing file');
-      await fs.promises.rm(cachePath, { recursive: true, force: true });
-    }
+        if (fs.existsSync(cachePath)) {
+          const [existingHash, currentHash] = await Promise.all([
+            this.hashFile(cachePath),
+            this.hashFile(currentPath),
+          ]);
+          if (existingHash !== currentHash) {
+            d('* Replacing existing file as it does not match our inbound file');
+            fs.promises.rm(cachePath, { recursive: true, force: true });
+          } else {
+            d('* Using existing file as the hash matches our inbound file, no need to replace');
+            return cachePath;
+          }
+        }
 
-    try {
-      await fs.promises.rename(currentPath, cachePath);
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === 'EXDEV') {
-        // Cross-device link, fallback to copy and delete
-        await fs.promises.cp(currentPath, cachePath, {
-          force: true,
-          recursive: true,
-          verbatimSymlinks: true,
-        });
-        await fs.promises.rm(currentPath, { force: true, recursive: true });
-      } else {
+        try {
+          await fs.promises.rename(currentPath, cachePath);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code === 'EXDEV') {
+            // Cross-device link, fallback to copy and delete
+            await fs.promises.cp(currentPath, cachePath, {
+              force: true,
+              recursive: true,
+              verbatimSymlinks: true,
+            });
+            await fs.promises.rm(currentPath, { force: true, recursive: true });
+          } else {
+            throw err;
+          }
+        }
+
+        return cachePath;
+      } catch (err) {
+        if (process.platform === 'win32' && (err as NodeJS.ErrnoException).code === 'EPERM') {
+          // On windows this normally means we're fighting another instance of @electron/get
+          // also trying to write this file to the cache
+          d('Experienced error putting thing in cache', err);
+          if (attemptsLeft > 0) {
+            d('Trying again in a few seconds');
+            await new Promise((resolve) => {
+              setTimeout(resolve, 2000);
+            });
+            return await attempt(attemptsLeft - 1);
+          }
+          d('We have already tried too many times, giving up...');
+        }
         throw err;
       }
-    }
+    };
 
-    return cachePath;
+    return await attempt();
   }
 }

--- a/test/GotDownloader.network.spec.ts
+++ b/test/GotDownloader.network.spec.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { GotDownloader } from '../src/GotDownloader';
 import { TempDirCleanUpMode, withTempDirectory } from '../src/utils';
-import { EventEmitter } from 'events';
+import { PathLike } from 'node:fs';
 
 describe('GotDownloader', () => {
   describe('download()', () => {
@@ -44,11 +44,12 @@ describe('GotDownloader', () => {
 
     it('should throw an error if the file write stream fails', async () => {
       const downloader = new GotDownloader();
+      const createWriteStream = fs.createWriteStream;
       const spy = vi.spyOn(fs, 'createWriteStream');
-      spy.mockImplementationOnce(() => {
-        const emitter = new EventEmitter();
-        setTimeout(() => emitter.emit('error', 'bad write error thing'), 10);
-        return emitter as fs.WriteStream;
+      spy.mockImplementationOnce((path: PathLike) => {
+        const stream = createWriteStream(path);
+        setTimeout(() => stream.emit('error', 'bad write error thing'), 10);
+        return stream;
       });
       await withTempDirectory(async (dir) => {
         const testFile = path.resolve(dir, 'test.txt');

--- a/test/GotDownloader.network.spec.ts
+++ b/test/GotDownloader.network.spec.ts
@@ -48,7 +48,7 @@ describe('GotDownloader', () => {
       const spy = vi.spyOn(fs, 'createWriteStream');
       spy.mockImplementationOnce((path: PathLike) => {
         const stream = createWriteStream(path);
-        setTimeout(() => stream.emit('error', 'bad write error thing'), 10);
+        setTimeout(() => stream.emit('error', 'bad write error thing'), 0);
         return stream;
       });
       await withTempDirectory(async (dir) => {


### PR DESCRIPTION
Double installs sometimes fight each other for the cache entry, let's back off a bit and then check if the thing in the cache matches the thing we're putting in and if so just accept it.