### PR TITLE
ci: expand test matrix to arm64 Windows and Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,9 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - ubuntu-24.04-arm
           - windows-latest
+          - windows-11-arm
     runs-on: "${{ matrix.os }}"
     steps:
       - run: git config --global core.autocrlf input


### PR DESCRIPTION
These are now generally available, so expanding our test matrix to ensure we test pulling binaries on these platforms.