### PR TITLE
ci: add required-ci aggregator job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,14 @@ jobs:
         run: yarn lint && yarn test
       - name: Build docs
         run: yarn build:docs
+
+  required-ci:
+    name: Required CI
+    if: always()
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check test results
+        if: needs.test.result != 'success' && needs.test.result != 'skipped'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,6 @@ jobs:
       - test
     runs-on: ubuntu-latest
     steps:
-      - name: Check test results
-        if: needs.test.result != 'success' && needs.test.result != 'skipped'
+      - name: Check job results
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: exit 1


### PR DESCRIPTION
## Summary
- Add a `Required CI` job that `needs: test` and runs with `if: always()`
- Fails the run if the `test` job result is anything other than `success` or `skipped`
- Gives branch protection a single, stable status check to require instead of listing every matrix variant

## Test plan
- [ ] CI passes on this PR
- [ ] `Required CI` reports success when all test matrix jobs pass
- [ ] `Required CI` reports failure when any test matrix job fails