### PR TITLE
build: drop redundant npx prefixes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "build:docs": "npx typedoc",
+    "build:docs": "typedoc",
     "eslint": "eslint --ext .ts src test",
     "lint": "npm run prettier && npm run eslint",
     "prepare": "husky",


### PR DESCRIPTION
typedoc and lint-staged are both devDependencies — `npx` is redundant. Use `yarn lint-staged` in the pre-commit hook to match the rest of the project.