### PR TITLE
test: fix race in FetchDownloader write-stream failure test

### DIFF
--- a/test/FetchDownloader.network.spec.ts
+++ b/test/FetchDownloader.network.spec.ts
@@ -50,10 +50,12 @@ describe('FetchDownloader', () => {
     it('should throw an error if the file write stream fails', async () => {
       const downloader = new FetchDownloader();
       const createWriteStream = fs.createWriteStream;
+      const writeError = new Error('ENOSPC: no space left on device, write');
       const spy = vi.spyOn(fs, 'createWriteStream');
       spy.mockImplementationOnce((path: PathLike) => {
         const stream = createWriteStream(path);
-        setTimeout(() => stream.emit('error', 'bad write error thing'), 0);
+        stream._write = (_chunk, _encoding, callback): void => callback(writeError);
+        stream._writev = (_chunks, callback): void => callback(writeError);
         return stream;
       });
       await withTempDirectory(async (dir) => {
@@ -63,8 +65,9 @@ describe('FetchDownloader', () => {
             'https://github.com/electron/electron/releases/download/v2.0.18/SHASUMS256.txt',
             testFile,
           ),
-        ).rejects.toMatchInlineSnapshot(`"bad write error thing"`);
+        ).rejects.toThrowError(writeError);
       }, TempDirCleanUpMode.CLEAN);
+      spy.mockRestore();
     });
 
     it('should download to a deep uncreated path', async () => {


### PR DESCRIPTION
## Summary

The `should throw an error if the file write stream fails` test emitted its error via `setTimeout(..., 0)`. With the fetch-based downloader, the ~2 KB response body is usually already buffered when `fetch()` resolves, so `pipeline()` can drain it entirely via microtasks and resolve successfully before the `setTimeout` macrotask fires. This caused the Release workflow on `main` to fail on macOS after #376 landed.

This injects the failure deterministically by overriding `_write` / `_writev` on the real `fs.WriteStream` so the error fires exactly when `pipeline()` flushes data to disk — the same path a real `ENOSPC` takes. Both overrides are required because chunks buffered during the async file-open (`_construct`) are drained via `_writev`, not `_write`.

Also switched the assertion to `rejects.toThrowError(writeError)` to verify the exact error instance propagates, and restored the spy after the test.

## Test plan

- [x] `yarn vitest run test/FetchDownloader.network.spec.ts` — 4/4 pass
- [x] Ran the previously-flaky test 5× consecutively — 5/5 pass
- [x] `yarn test` — full suite green
- [x] `yarn lint` — clean